### PR TITLE
Patch 1

### DIFF
--- a/parallel_bleeding_edge/src/initialize_parent.f
+++ b/parallel_bleeding_edge/src/initialize_parent.f
@@ -677,6 +677,21 @@ c     profilefile comes from MESA
      $        star_mass_n14,star_mass_o16,star_mass_ne20,he_core_mass,       
      $        c_core_mass,o_core_mass,si_core_mass,fe_core_mass,             
      $        neutron_rich_core_mass
+     
+         if((num_zones .gt. kdm).and.(myrank .eq. 0)) then
+              print *, "Too many zones in the MESA profile!"
+              print *, "Edit the value of 'kdm' in starsmasher.h to use"//
+     $             " more."
+              print *, "num_zones = ",num_zones
+              print *, "Max allowed zones kdm = ", kdm
+              write(69,*) "Too many zones in the MESA profile!"
+              write(69,*) "Edit the value of 'kdm' in starsmasher.h to "//
+     $             "use more."
+              write(69,*) "num_zones = ",num_zones
+              write(69,*) "Max allowed zones kdm = ", kdm
+              error stop
+         end if
+     
          read(io,*)             ! blank line
          read(io,*)             ! list of integers                   
 

--- a/parallel_bleeding_edge/src/starsmasher.h
+++ b/parallel_bleeding_edge/src/starsmasher.h
@@ -67,7 +67,7 @@
       common/inputfilenames/startfile1,startfile2,eosfile,opacityfile,profilefile
       common/courantnumbers/ cn1,cn2,cn3,cn4,cn5,cn6,cn7
       common/integration/nintvar,neos,nusegpus,nselfgravity,ncooling,nkernel
-      parameter(kdm=5000)
+      parameter(kdm=10000)
       integer ntypes,cc(nmax)
       parameter(ntypes=32)
       common/softening/cc


### PR DESCRIPTION
This is to help users that might end up using large MESA profile files. Max number of zones "kdm" allowed was set to 10,000 (up from 5,000) in starsmasher.h. An error message was added to initialize_parent.f.