### PR TITLE
Sync parallel_bleeding_edge/src with current working version

### DIFF
--- a/parallel_bleeding_edge/src/SPHgrav_lib2/Makefile
+++ b/parallel_bleeding_edge/src/SPHgrav_lib2/Makefile
@@ -1,7 +1,3 @@
-# Take into account the localtion of CUDAPATH and the
-# "-abi=no" flag in NVCCFLAGS
-# Pau Amaro Seoane, Berlin 24 August 2024
-
 .SUFFIXES: .cu 
 
 CXX  := g++
@@ -9,21 +5,23 @@ CC   := gcc
 AR   := ar ruv
 RANLIB := ranlib
 
-# Path to your CUDA installation
-# Make sure you do not have different versions installed.
-# If that's the case, use the same CUDAPATH here and in the
-# main folder, and choose the most recent version for both.
-
-CUDAPATH       := /usr/local/cuda-12.6
+# Path to your CUDA installation: CUDAPATH should contain the directory lib64 that contains libcudart.so as well as the bin directory that contains nvcc
+CUDAPATH       := $(shell dirname $(shell dirname $(shell which nvcc)))
 CUDAINCLUDE    := -I$(CUDAPATH)/include
 NVCC           := $(CUDAPATH)/bin/nvcc
 
-# Remove the "-abi=no" flag to avoid bug
-#
-NVCCFLAGS := -arch=sm_75
-#NVCCFLAGS += -O4 -g  $(CUDAINCLUDE)  -I./ -Xptxas -v,-abi=no 
-NVCCFLAGS += -O4 -g  $(CUDAINCLUDE)  -I./ -Xptxas -v
+# Automatically determine the compute capability of the GPU
+COMPUTE_CAPABILITY := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.')
 
+
+# Check if the capability is empty (no GPU detected) and set default value to 90 if so
+ifneq ($(COMPUTE_CAPABILITY),)
+    NVCCFLAGS := -arch=sm_$(COMPUTE_CAPABILITY)
+else
+    NVCCFLAGS := -arch=sm_89  # 5.2 for carrv122, 2.0 for gonzales, 6.1 for physics, 8.0 for a100, 9.0 for h100
+endif
+
+NVCCFLAGS += -O4 -g  $(CUDAINCLUDE)  -I./ -Xptxas -v ##########,-abi=no 
 NVCCFLAGS += -Xcompiler="-Wall"
 CUDA_LIBS = -L$(CUDAPATH)/lib64 -lcudart
 
@@ -37,17 +35,16 @@ GRAVLIB = libSPHgrav.a
 all: $(GRAVLIB)
 
 $(GRAVLIB): $(OBJS)
-	/bin/rm -f $@
-	$(AR) $@ $(OBJS)
+	    /bin/rm -f $@
+	    $(AR) $@ $(OBJS)
 
 .cpp.o: 
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 %.cu_o:  %.cu
-	$(NVCC) $(NVCCFLAGS) -c $< -o $@
+	 $(NVCC) $(NVCCFLAGS) -c $< -o $@
 
 clean:
 	/bin/rm -rf *.cu_o $(GRAVLIB)
 
 $(GRAVLIB): cutil.h cuVec3.h cuVector.h
-

--- a/parallel_bleeding_edge/src/SPHgrav_lib2/grav_force_direct.cu
+++ b/parallel_bleeding_edge/src/SPHgrav_lib2/grav_force_direct.cu
@@ -524,10 +524,12 @@ struct SPHgrav_direct
     {
       cudaDeviceProp p;
       assert(cudaGetDeviceProperties(&p, dev) == cudaSuccess);
+      int computeMode = -1;
+      cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, dev);
       const bool supported = p.major > 1 || (p.major == 1 && p.minor >= 3);
       if (rank == 0)
         fprintf(stderr,"  Device= %d: %s computeMode= %d computeCapability= %d_%d  supported= %s\n", 
-            dev, p.name, p.computeMode, p.major, p.minor, supported ? "YES" : "NO");
+            dev, p.name, computeMode, p.major, p.minor, supported ? "YES" : "NO");
       no_supported += supported ? 1 : 0;
       can_use_device[dev] = true;
     }

--- a/parallel_bleeding_edge/src/changetf.f
+++ b/parallel_bleeding_edge/src/changetf.f
@@ -63,7 +63,7 @@ c      character*1 stara,starb,starc
       character*9 starname(3)
       save starname
       integer numstars,lastnumstars
-      data lastnumstars /3/
+      data lastnumstars /2/
       save lastnumstars
       real*8 lastamb,lastamg,lastamr
       save lastamb,lastamg,lastamr
@@ -104,6 +104,9 @@ c      character*1 stara,starb,starc
       integer idumb
       save idumb
       data idumb /-2391/
+      real*8 orbital_period
+      
+      state=''
 
 c synchronize all variables:
       do i=1,n
@@ -379,6 +382,7 @@ c         if(myrank.eq.0)write(69,*)'timelast being set to',timelast
       compinabinary(3)=.false.
       compinabinary(4)=.false.
       a12=1.d30
+      ecc12=0d0
 
       tfold=tf
       tjumpaheadold=tjumpahead
@@ -672,16 +676,26 @@ c               endif
          eccbg=-1.d0
       endif
 
+      if(numstars.eq.2 .and. ecc12.ge.0 .and. ecc12.lt.1) then
+         orbital_period=2*pi*a12**1.5d0*(mass1+mass2)**(-0.5d0)
+         if(myrank.eq.0)write(69,*)'bound orbit with orbital period=',
+     $        orbital_period
+         if(t+orbital_period.lt.10000*DTOUT) then
+            tf=min(10000*DTOUT,max(tfold,t+30.d0*DTOUT))
+         endif
+         tjumpahead=1.d30
+      endif         
+
       timelast=t
       if(numstars.ne.lastnumstars) then
          if(myrank.eq.0)write(69,*)lastnumstars-numstars+1,'stars have merged'
-         if(t.gt.1 .and. tjumpahead.ge.0.d0) then
-            tf=min(tfold,dble(nint(t+4000.d0)))
+         if(t.gt.DTOUT .and. tjumpahead.ge.0.d0) then
+            tf=max(tfold,t+30.d0*DTOUT)
             tjumpahead=1.d30
          endif
          if(lastnumstars-numstars.gt.1) then
             if(myrank.eq.0)write(69,*)'two stars disappeared at once?'
-            tf=max(tfold,dble(nint(t+4000.d0)))
+            tf=max(tfold,t+30.d0*DTOUT)
             tjumpahead=1.d30
 c            stop
          endif
@@ -704,7 +718,7 @@ c            stop
          else
             if(myrank.eq.0)write(69,*)'cannot determine absorber',
      $           deltaamb,deltaamg,deltaamr
-            stop
+            absorber=absorbee
          endif
          lastnumstars=numstars
          if(myrank.eq.0)write(69,*)'star ',trim(starname(absorber)),
@@ -713,33 +727,39 @@ c            stop
          starname(absorber)=
      $        '{'//trim(starname(absorber))//','
      $        //trim(starname(absorbee))//'}'
-      else if(numstars.gt.1 .and. ecc12.ge.1.d0 .and.
+      else if(numstars.gt.1 .and. ecc12.gt.0.99d0 .and.
      $        dotproduct12.gt.0) then
-         if(myrank.eq.0)write(69,*)
-     $        'the stars have not merged, and they never will: ecc=',ecc12
-         tf=min(tfold,dble(nint(t+4000.d0)))
+         if(ecc12.ge.1.d0) then
+            if(myrank.eq.0)write(69,*)
+     $           'the stars have not merged, and they never will: ecc=',ecc12
+            tf=min(tfold,t+30.d0*DTOUT)
+         else
+            if(myrank.eq.0)write(69,*)
+     $           'the stars will take a long time to orbit, we might give up: ecc=',ecc12
+         endif
          tjumpahead=1.d30
       else if(numstars.gt.1) then
          if(ecc12.gt.1.d0) then
             if(myrank.eq.0)write(69,*)
-     $           'the stars have not merged, but they may still'
+     $           'the stars have not merged, but they may still: ecc=',ecc12
             tjumpahead=1.d30
          else
             if(myrank.eq.0)write(69,*)
-     $           'the stars have not merged, but they will'
+     $           'the stars have not merged, but they will: ecc=',ecc12
             if(dotproduct12.gt.0 .and. a12*(1.d0+ecc12).gt.
      $           1000.d0) then
-c               tjumpahead=1d30
-               tjumpahead=min(tjumpahead,dble(nint(t+4000.d0)))
+               tjumpahead=1d30
+c               tjumpahead=min(tjumpahead,dble(nint(t+4000.d0)))
 c               tjumpahead=min(tjumpahead,dble(nint(t+75.d0+25*ran1(idumb))))
-               tf=max(dble(nint(tjumpahead+4000.d0)),tf)
+               if(myrank.eq.0)write(69,*)'FUTURE CANDIDATE FOR JUMPING AHEAD'
+               tf=max(tjumpahead+30.d0*DTOUT,tf)
             else
                if(myrank.eq.0)write(69,*)'not going to jump ahead (',dotproduct12,
      $              a12*(1.d0+ecc12),')!'
                tjumpahead=1.d30
             endif
          endif
-         tf=dble(nint(t+4000.d0))
+         tf=max(tfold,t+30.d0*DTOUT)
       endif
       tjumpahead=abs(tjumpahead)
       lastamb=amb
@@ -756,9 +776,9 @@ c     p=(gam-1)*rho*u=a*rho^gam, so u=a*rho^(gam-1)/(gam-1)
                eint=eint+am(i)*u(i)
             endif
          enddo
-         if(abs(1.d0-eint/eintsave).gt.0.01d0) then
+         if(abs(1.d0-eint/eintsave).gt.0.01d0 .and. numstars.gt.0) then
             if(myrank.eq.0)write(69,*)'u is changing a lot: will integrate longer'
-            tf=max(tfold,dble(nint(t+1000.d0)))
+            tf=max(tfold,t+30.d0*DTOUT)
 c            tjumpahead=1.d30
          endif
       endif
@@ -1054,7 +1074,7 @@ c            if(myrank.eq.0)write(69,*)'debug r12=',r12,ambin,a12,a12*(1.d0-ecc1
                state='(1,2,3)'
             endif
 
-            tf=max(tfold,dble(nint(t+4000.d0)))
+            tf=max(tfold,t+30.d0*DTOUT)
             tjumpahead=1.d30
 
          else
@@ -1064,8 +1084,9 @@ c     there is a binary and a third star that is both not bound and not headed c
      $           trim(starname(istarc))
  102        format('(',a,',',a,'),',a)
 
-            tjumpahead=min(tjumpahead,dble(nint(t+100.d0)))
-            tf=max(dble(nint(tjumpahead+4000.d0)),tf)
+c            tjumpahead=min(tjumpahead,dble(nint(t+100.d0)))
+            tjumpahead=1.d30
+            tf=max(tjumpahead+30.d0*DTOUT,tf)
 
          endif
          
@@ -1428,11 +1449,15 @@ c     shift back to original inertial reference frame:
 
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      write(23,'(d12.5,3d16.8,33d12.4)') t,amb,amg,amr,
-     $     xb,yb,zb,xg,yg,zg,xr,yr,zr,
-     $     dbg,dbr,dgr,am4/amtot,am4,
-     $     abg,eccbg,abr,eccbr,agr,eccgr,abin3,eccbin3,
-     $     ebin3ebin,mejecta
+c      write(23,'(d12.5,3d16.8,33d12.4)') t,amb,amg,amr,
+c     $     xb,yb,zb,xg,yg,zg,xr,yr,zr,
+c     $     dbg,dbr,dgr,am4/amtot,am4,
+c     $     abg,eccbg,abr,eccbr,agr,eccgr,abin3,eccbin3,
+c     $     ebin3ebin,mejecta
+      write(23,'(33g14.6)') t,amb,amg,
+     $     xb,yb,zb,xg,yg,zg,
+     $     dbg,am4/amtot,am4,
+     $     abg,eccbg,mejecta
 
 c asynchronize all variables:
       do i=1,n

--- a/parallel_bleeding_edge/src/compbest3.f
+++ b/parallel_bleeding_edge/src/compbest3.f
@@ -27,6 +27,7 @@ c     numbers for a summary table
       logical db,pp
       character*18 fname
       integer ncomp1,ncomp2,ncomp3,ncomp4,corepts,corepts1
+      integer ncompsph1,ncompsph2
       real*8 amtiny
       integer irhomax4,irhomax1,irhomax2,irhomax3
       save irhomax4,irhomax1,irhomax2,irhomax3
@@ -476,9 +477,12 @@ c               write(69,*)x(i),y(i),z(i)
          if(myrank.eq.0)write(69,*)'let us try again'
          checkifswapped=.true.
          firstt=.false.
+         return
          goto 123
       endif
 
+      ncompsph1=0
+      ncompsph2=0
       ncomp1=0
       ncomp2=0
       ncomp3=0
@@ -487,8 +491,10 @@ c               write(69,*)x(i),y(i),z(i)
       do i=1,n
          if (icomp(i).eq.1) then
             ncomp1=ncomp1+1
+            if(u(i).ne.0) ncompsph1=ncompsph1+1
          else if (icomp(i).eq.2) then
             ncomp2=ncomp2+1
+            if(u(i).ne.0) ncompsph2=ncompsph2+1
          else if (icomp(i).eq.3) then
             ncomp3=ncomp3+1
          else if (icomp(i).eq.4) then
@@ -496,6 +502,40 @@ c               write(69,*)x(i),y(i),z(i)
             ncomp4=ncomp4+1
          endif
       enddo
+
+c     A component will need at least 5 SPH particles to count
+      if(ncompsph1.ge.1 .and. ncompsph1.le.4) then
+         do i=1,n
+            if (icomp(i).eq.1) then
+               icomp(i)=4
+               am4=am4+am(i)
+            endif
+         enddo
+         am1=0
+         ncomp1=0
+         x1=0
+         y1=0
+         z1=0
+         vx1=0
+         vy1=0
+         vz1=0
+      endif
+      if(ncompsph2.ge.1 .and. ncompsph2.le.4) then
+         do i=1,n
+            if (icomp(i).eq.2) then
+               icomp(i)=4
+               am4=am4+am(i)
+            endif
+         enddo
+         am2=0
+         ncomp2=0
+         x2=0
+         y2=0
+         z2=0
+         vx2=0
+         vy2=0
+         vz2=0
+      endif
 
       numstars=min(ncomp1,1)+min(ncomp2,1)+min(ncomp3,1)
 
@@ -511,7 +551,7 @@ c               write(69,*)x(i),y(i),z(i)
             firstt=.true.
             goto 123
          else
-            stop
+            return
          endif
       else
          firstt=.false.

--- a/parallel_bleeding_edge/src/init.f
+++ b/parallel_bleeding_edge/src/init.f
@@ -105,6 +105,15 @@ c     used in subroutine dump)
      $           ngrold,nrelaxold,trelaxold,dt,omega2
          endif
 
+         if(nnoptold.ne.nnopt) then
+            if(myrank.eq.0) then
+               write(69,*) 'NOTE: Currently nnopt=',nnopt
+               write(69,*) '      The NNOPT in restartrad.sph=',nnoptold
+               write(69,*) '      Changing NNOPT to be',nnoptold
+            endif
+            nnopt=nnoptold
+         endif
+
          if(dtoutold.ne.dtout) then
             if(myrank.eq.0)write(69,*)'nout from restartrad.sph is',nout
             nout = t/dtout-1
@@ -113,8 +122,12 @@ c     used in subroutine dump)
 
          if(tjumpahead.gt.0) tjumpahead=-tjumpahead ! negative tjumpahead is so that tjumpahead will not be changed by changetf just because old eint value is not known in changetf
 
-c         tf=sign(max(abs(tfold),abs(tf)),tf)
-
+         if(t.ge.abs(tf)) then
+c     In case the user is restarting but hasn't made the final time late enough for anything to happen:
+            tf=sign(max(abs(tfold),abs(tf)),tf)
+            if(myrank.eq.0) write(69,*) 'Reset final time to TF=',tf
+         endif
+         
          if(myrank.eq.0) then
             write(69,*) myrank,'tjumpahead=',tjumpahead,'tf=',tf
          endif
@@ -493,6 +506,10 @@ c      end
       logical autotf
       common/autotfblock/autotf
       common/orbitalelements/e0,semimajoraxis,impactparameter,vinf2
+      real*8 bbh_m1,bbh_m2,bbh_rp,bbh_semimajoraxis,bbh_vinf2,
+     $     bbh_e0,bbh_trueanomaly,bbh_argperi,bbh_inclination,bbh_longitude
+      common/bbhinfo/bbh_m1,bbh_m2,bbh_rp,bbh_semimajoraxis,bbh_vinf2,
+     $     bbh_e0,bbh_trueanomaly,bbh_argperi,bbh_inclination,bbh_longitude
       real*8 rhocgs,mucgs
       common/ueqstuff/rhocgs,teq,mucgs
       common /jumpcomm/ tjumpahead
@@ -509,7 +526,15 @@ c      end
      $     omega_spin,neos,nselfgravity,gam,reat,starmass,starradius,
      $     ncooling,teq,tjumpahead,startfile1,startfile2,eosfile,
      $     opacityfile,profilefile,nkernel,throwaway,
-     $     stellarevolutioncodetype,rp
+     $     stellarevolutioncodetype,
+     $     bbh_m1,bbh_m2,bbh_rp,bbh_semimajoraxis,bbh_vinf2,
+     $     bbh_e0,bbh_trueanomaly,bbh_argperi,bbh_inclination,
+     $     bbh_longitude,rp
+      
+      character*9 slurm_gpu_count_str
+      integer slurm_gpu_count, actual_gpu_count,ios
+      character*20 gpucfilename
+      character*50 command
 
       ndisplace=0
       displacex=0d0
@@ -521,6 +546,17 @@ c      end
       rp=-1.d30
       e0=-1.d30
       vinf2=1.d30
+
+      bbh_m1=20d0
+      bbh_m2=10d0
+      bbh_semimajoraxis=0.d0
+      bbh_rp=-1.d30
+      bbh_e0=-1.d30
+      bbh_vinf2=1.d30
+      bbh_trueanomaly=0d0
+      bbh_argperi=0d0
+      bbh_inclination=0d0
+      bbh_longitude=0d0
 
 c     set some default values, so that they don't necessarily have to be set in the sph.input file:
       tf=50000                 ! desired final time to stop simulation
@@ -545,16 +581,16 @@ c     set some default values, so that they don't necessarily have to be set in 
       tscanon=0                ! time that the scan of a binary starts
       sepfinal=1.d30           ! final separation for the scan of a binary
       nintvar=2                ! 1=integrate entropic variable a, 2=integrate internal energy u
-      ngravprocs=-2            ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
+      ngravprocs=0             ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
       qthreads=0               ! number of gpu threads per particle. typically set to 1, 2, 4, or 8.  set to a negative value to optimize the number of threads by timing.  set to 0 to guess the best number of threads without timing.
       mbh=10d0                 ! mass of black hole
-      runit=6.9599d10          ! number of cm in the unit of length.  use 6.9599d10 if want solar radius.
-      munit=1.9891d33          ! number of g in unit of mass.  use 1.9891d33 if want solar mass.
+      runit=6.957d10          ! number of cm in the unit of length.  use 6.957d10 if want MESA solar radius.
+      munit=1.9884098706980504d33          ! number of g in unit of mass.  use 1.9884098706980504E+033 if want MESA solar mass.
 !     the courant numbers cn1, cn2, cn3, and cn4 are for sph particles:
 !     dt_sph=1/(1/dt1 + 1/dt2 + 1/dt3 + 1/dt4)
-      cn1=.5d0                 ! dt1=cn1*h/v_signal
-      cn2=0.06d0               ! dt2=cn2*(h/|a-a_smoothed|)^0.5
-      cn3=0.06d0               ! dt3=cn3*u/|du/dt|
+      cn1=.3d0                 ! dt1=cn1*h/v_signal
+      cn2=1.d30                ! dt2=cn2*(h/|a-a_smoothed|)^0.5
+      cn3=0.1d0                ! dt3=cn3*u/|du/dt|
       cn4=1.d30                ! dt4=cn4*v_signal/|a-a_smoothed|
 !     the courant numbers cn5, cn6, and cn7 are for a particle i that is a compact object (co):
 !     dt_co=1/(1/dt5 + 1/dt6)
@@ -564,7 +600,7 @@ c     set some default values, so that they don't necessarily have to be set in 
 !     the final timestep dt is the minimum of dt_sph and dt_co for all particles i
       computeexclusivemode=0   ! set this to 1 if on machine like grapefree with gpus in compute exclusive mode; set this to 0 on supercomputers like lincoln
       omega_spin=0.d0 ! angular rotation rate of star, used in nrelax=1 relaxations to give a rigidly rotating model
-      ppn=12
+      ppn=16
       neos=1 ! 0 for polytropic equation of state (eos), 1 for ideal gas + radiation pressure, 2 for tabulated eos
       nselfgravity=1 ! 0 if just do gravity to point particles, 1 if self-gravitating
       gam=5.d0/3.d0 ! leave this set at a reasonable value even if using neos=1 or 2 (because the value of gam is used in estimating the local sound speed in balav3.f)
@@ -587,6 +623,48 @@ c     set some default values, so that they don't necessarily have to be set in 
       read(12,input)
       close(12)
 
+      call set_nusegpus         ! if using gpus, this sets nusegpus=1 *and* nselfgravity=1
+
+c      call system('env')
+
+      if(nusegpus.gt.0) then
+         write(gpucfilename, '(A,I2.2)') 'temp_gpu_count_', myrank
+         command = 'nvidia-smi -L | wc -l > ' // trim(gpucfilename)
+c         call execute_command_line(trim(command))
+         call system(trim(command))
+
+c     Read the result from the temporary file
+         open(unit=400+myrank, file=gpucfilename, status='old',
+     $        action='read', iostat=ios)
+         if (ios /= 0) then
+            print *, 'Error opening tempgpucount.txt'
+            actual_gpu_count = abs(ngravprocs)
+         else
+         
+            read(400+myrank, *) actual_gpu_count
+            close(400+myrank)
+c     write(100+myrank,*) actual_gpu_count,ios
+c     Clean up temporary file
+c     call execute_command_line('rm -f ' // trim(gpucfilename))
+            call system('rm -f ' // trim(gpucfilename))
+         endif
+         call getenv('SLURM_GPUS_ON_NODE', slurm_gpu_count_str)
+!     Convert the string to an integer
+         read(slurm_gpu_count_str, '(I1)', IOSTAT=ierr) slurm_gpu_count
+c         write(200+myrank,*) slurm_gpu_count, ierr
+         if (ierr == 0 .and. slurm_gpu_count.gt.0) then
+            if(ngravprocs.eq.0 .or. ngravprocs.gt.slurm_gpu_count)then
+               ngravprocs=-slurm_gpu_count
+            endif
+         else
+            if(ngravprocs.eq.0 .or. ngravprocs.gt.actual_gpu_count)then
+               ngravprocs=-actual_gpu_count
+            endif
+         endif
+      endif
+
+c      write(300+myrank,*)'ngravprocs=',ngravprocs
+
       if(nitpot.ne.1 .and. ngr.ne.0) then
          if(myrank.eq.0) then
             write(69,*)'Gravitational potential energy is calculated at'
@@ -607,8 +685,6 @@ c     set some default values, so that they don't necessarily have to be set in 
 
       if(myrank.eq.0 .and. ncooling.gt.0) write(69,*)
      $     'background temperature teq=',teq
-
-      call set_nusegpus         ! if using gpus, this sets nusegpus=1 *and* nselfgravity=1
 
       if(cn1.lt.0.d0 .or. cn2.lt.0.d0 .or. cn3.lt.0.d0 .or.
      $     cn4.lt.0.d0 .or. cn5.lt.0.d0 .or. cn6.lt.0.d0 .or.
@@ -642,7 +718,12 @@ c      endif
          autotf=.true.
          tf=abs(tf)
          open(23,file='ecc.sph')
-         open(34,file='jumpahead.sph')
+         write(23,'(33a14)') 't    ','m1    ','m2    ',
+     $     'x1    ','y1    ','z1    ','x2    ','y2    ','z2    ',
+     $     'd12    ','am4/amtot    ','am4    ',
+     $     'a12    ','ecc12    ','mejecta    '
+
+c         open(34,file='jumpahead.sph')
       endif
 
       return
@@ -788,6 +869,16 @@ c     used in subroutine dump)
      $     tfold,dtoutold,noutold,nitold,told,navold,
      $     alphaold,betaold,tjumpahead,ngrold,nrelaxold,
      $     trelaxold,dt
+
+      if(nnoptold.ne.nnopt) then
+         if(myrank.eq.0) then
+            write(69,*) 'NOTE: Currently nnopt=',nnopt
+            write(69,*) '      The NNOPT in startu.sph=',nnoptold
+            write(69,*) '      Changing NNOPT to be',nnoptold
+         endif
+         nnopt=nnoptold
+      endif
+
       do i=1,ntot
          read (12) x(i),y(i),z(i),am(i),hp(i),rho(i),vx(i),vy(i),
      $        vz(i),vxdot(i),vydot(i),vzdot(i),u(i),udot(i),

--- a/parallel_bleeding_edge/src/initialize_asciiimage.f
+++ b/parallel_bleeding_edge/src/initialize_asciiimage.f
@@ -5,61 +5,81 @@ c      parameter(imax=900,jmax=229)
       parameter(imax=900,jmaxmax=999)
       character *1 line(imax)
       real*8 density(imax,jmaxmax)
-      real*8 filledcell,xtry,ytry
 
-      filledcell=0
+      ip=0
       open(12,file='sph.image')
       do j=1,jmaxmax
          read(12,'(900a1)',end=20)(line(i), i=1,imax)
          do i=1,imax
-            if(line(i).eq.' ') then
-               density(i,j)=0d0
+            if (line(i) == ' ') then
+               density(i,j) = 0d0
+            else if (line(i) == '.') then
+               density(i,j) = 0.15d0
+            else if (line(i) == ':') then
+               density(i,j) = 0.25d0
+            else if (line(i) == '-') then
+               density(i,j) = 0.40d0
+            else if (line(i) == '=') then
+               density(i,j) = 0.55d0
+            else if (line(i) == '+') then
+               density(i,j) = 0.60d0
+            else if (line(i) == '*') then
+               density(i,j) = 0.75d0
+            else if (line(i) == '#') then
+               density(i,j) = 0.92d0
+            else if (line(i) == '%') then
+               density(i,j) = 0.98d0
+            else if (line(i) == '@') then
+               density(i,j) = 1.00d0
+            else if (line(i) == '$') then
+               density(i,j) = 0.97d0
+            else if (line(i) == '&') then
+               density(i,j) = 0.90d0
             else
-               density(i,j)=1d0
-               filledcell=filledcell+density(i,j)
+               density(i,j) = 0.5d0
             endif
+            if(density(i,j).gt.0) then
+               ip = ip + 1
+            endif
+
          enddo
       enddo            
  20   close(12)
+      n = ip
+      ntot = n
+
 
       jmax=j-1
       if(myrank.eq.0) then
+         write(69,*) 'number of particles n=',n
          write(69,*) 'jmax=',jmax
-         write(69,*) 'filledcell=',filledcell
+         call flush(69)
       endif
 
       ip=0
       do ix=1,imax
          do iy=1,jmax
-            xtry=ix
-            ytry=jmax-iy
             if(density(ix,iy).gt.0d0)then
                ip=ip+1
-               x(ip)=xtry
-               y(ip)=ytry
+               x(ip)=ix * 0.55d0
+               y(ip)=jmax-iy
                z(ip)=0d0
-               vx(ip)=(xtry/imax-0.5d0)/(0.5d0*imax*jmax)**0.25
-               vy(ip)=(ytry/jmax-0.5d0)/(0.5d0*imax*jmax)**0.25
+               vx(ip)=(dble(ix)/imax-0.5d0)/(0.5d0*imax*jmax)**0.25
+               vy(ip)=(y(ip)/jmax-0.5d0)/(0.5d0*imax*jmax)**0.25
                vz(ip)=0d0
                u(ip)=1d0/sqrt(0.5d0*imax*jmax)
                vxdot(ip)=0d0
                vydot(ip)=0d0
                vzdot(ip)=0d0
                udot(ip)=0d0
-               hp(ip)=0.5d0*
-     $              (3d0*1.9d0*nnopt/4d0/pi*imax*jmax/filledcell)**(1d0/3d0)
+               hp(ip)=0.55d0 * 0.5d0*
+     $              (3d0*1.9d0*nnopt/4d0/pi*imax*jmax/n)**(1d0/3d0)
                meanmolecular(ip)=
      $              1.67262158d-24/(2*0.7d0+0.75d0*0.28d0+0.5d0*0.02d0)
+               am(ip)=density(ix,iy)/n
             endif
          enddo
       enddo
-      n=ip
-      ntot=n
-      do ip=1,n
-         am(ip)=1d0/n
-      enddo
-
-      if(myrank.eq.0) write(69,*) 'number of particles n=',n
 
       call lfstart
 

--- a/parallel_bleeding_edge/src/initialize_bpbh.f
+++ b/parallel_bleeding_edge/src/initialize_bpbh.f
@@ -107,7 +107,7 @@ c     place velocities at same time as everything else:
       vx(i)=0.d0
       vy(i)=0.d0
       vz(i)=0.d0
-      am(i)=bhmass*1.98843d33/munit
+      am(i)=bhmass*1.9884098706980504d33/munit
       am2=am(i)
       hp(i)=-999.d0
       rho(i)=0.d0
@@ -131,8 +131,8 @@ c     place velocities at same time as everything else:
       open(30,file='m1m2rp.sph')
 c     make file m1m2rp.sph with masses and radius in solar units
       write(30,*) n1,n2,rp
-      write(30,*) am1*munit/1.98843d33,am2*munit/1.98843d33,
-     $     rp*runit/6.9599d10     
+      write(30,*) am1*munit/1.9884098706980504d33,am2*munit/1.9884098706980504d33,
+     $     rp*runit/6.957d10     
       close(30)
 
       k=am1*am2

--- a/parallel_bleeding_edge/src/initialize_bps.f
+++ b/parallel_bleeding_edge/src/initialize_bps.f
@@ -55,7 +55,7 @@ c break.  and that doesn't seem to be happening fortunately!
       real*8 deltax2,deltay2,deltaz2,deltavx2,deltavy2,deltavz2
       real*8 deltax3,deltay3,deltaz3,deltavx3,deltavy3,deltavz3
       real*8 egsol,solrad
-      parameter(egsol=1.9891d+33,solrad=6.9599d10)
+      parameter(egsol=1.9884098706980504d33,solrad=6.957d10)
       real*8 xcombin,ycombin,zcombin
       real*8 vxcombin,vycombin,vzcombin
       real*8 amtot

--- a/parallel_bleeding_edge/src/initialize_corotating.f
+++ b/parallel_bleeding_edge/src/initialize_corotating.f
@@ -20,7 +20,7 @@ c     calls gravquant,lfstart
       real*8 am1chk,am2chk,realdummy1,realdummy2,realdummy3
       real*8 deltax1,deltay1,deltaz1,deltax2,deltay2,deltaz2
       real*8 egsol,solrad
-      parameter(egsol=1.9891d+33,solrad=6.9599d10)
+      parameter(egsol=1.9884098706980504d33,solrad=6.957d10)
       real*8 deltaxbin,deltaybin,deltazbin
       character*7 dummy
 

--- a/parallel_bleeding_edge/src/initialize_hyperbolic.f
+++ b/parallel_bleeding_edge/src/initialize_hyperbolic.f
@@ -16,9 +16,9 @@
       integer idumb
       real*8 costh1,sinth1,costh2,sinth2,ps1,ps2
       real*8 xold,yold,zold,vxold,vyold,vzold,ran1
-      real*8 am1,am2
-c      real*8 xcm1,ycm1,zcm1,xcm2,ycm2,zcm2,am1,am2,am1tot,am2tot
-c      common/centersofmass/xcm1,ycm1,zcm1,xcm2,ycm2,zcm2,am1,am2
+      real*8 xnew,ynew,znew,vxnew,vynew,vznew
+      real*8 xcm1,ycm1,zcm1,xcm2,ycm2,zcm2,am1,am2
+      common/centersofmass/xcm1,ycm1,zcm1,xcm2,ycm2,zcm2,am1,am2
       real*8 amass1,amass2
       common/forcompbest/ amass1,amass2
       real*8 eorb0,xx
@@ -33,9 +33,17 @@ c      common/centersofmass/xcm1,ycm1,zcm1,xcm2,ycm2,zcm2,am1,am2
       real*8 divv(nmax)
       common/commdivv/divv
       common/orbitalelements/e0,semimajoraxis,impactparameter,vinf2
-      real*8 xcmparent,ycmparent,zcmparent,vxcmparent,vycmparent,vzcmparent
-      real*8 hprms
+      real*8 bbh_m1,bbh_m2,bbh_rp,bbh_semimajoraxis,bbh_vinf2,
+     $     bbh_e0,bbh_trueanomaly,bbh_argperi,bbh_inclination,bbh_longitude
+      common/bbhinfo/bbh_m1,bbh_m2,bbh_rp,bbh_semimajoraxis,bbh_vinf2,
+     $     bbh_e0,bbh_trueanomaly,bbh_argperi,bbh_inclination,bbh_longitude
+      real*8 xcmparent,ycmparent,zcmparent,
+     $     vxcmparent,vycmparent,vzcmparent
+      real*8 hprms,bbh_sep0
+      logical passivelyAdvected
 
+      nrelax=0
+      
       call cpu_time(time1)
 
       corepts=0
@@ -88,7 +96,6 @@ c      if(twofiles) then
       else
          costh1=1.d0
          sinth1=0.d0
-c         ps1=-0.645772d0        ! 37 degrees
          ps1=0d0
       endif
 
@@ -154,6 +161,7 @@ c     place velocities at same time as everything else:
          vy(i)=vy(i)-vycmparent
          vz(i)=vz(i)-vzcmparent
       enddo
+      passivelyAdvected = .false.
 
       if(twofiles) then
          if(myrank.eq.0) write (69,*)
@@ -262,51 +270,335 @@ c     place velocities at same time as everything else:
             vy(i)=vy(i)-vycmparent
             vz(i)=vz(i)-vzcmparent
          enddo
+
+         if(passivelyAdvected) then
+            if(myrank.eq.0) write(69,*)'Reading in aa and bb values...',ntot
+            open(99,file='sph.passivelyAdvected',status='old')
+            do i=1,ntot
+               read(99,*) aa(i),bb(i),dd(i)
+            enddo
+            close(99)
+         endif
+
       else
+c     There is only one start file, so the second object will be a single or
+c     binary compact object
+         if(passivelyAdvected) then
+            if(myrank.eq.0) write(69,*)'Reading in aa and bb values...',n1
+            open(99,file='sph.passivelyAdvected',status='old')
+            do i=1,n1
+               read(99,*) aa(i),bb(i),dd(i)
+            enddo
+            close(99)
+         endif
+            
+         hprms=0d0
+         do i=1,n1
+            hprms=hprms+hp(i)**2
+         enddo
+         hprms=sqrt(hprms/n1)
+         if(myrank.eq.0) then
+            write(69,*) 'rms smoothing length h in star=',hprms
+         endif
+         
          if(myrank.eq.0) write (69,*)
      $        'startfile2 ',
      $        trim(startfile2),
-     $        ' does not exist: will use compact object ',
-     $        'particle instead'
-         
-         n2=1
-         ntot=n1+n2
-         i=ntot
-         am2=mbh
-         am(i)=am2
-         x(i)=0.d0
-         y(i)=0.d0
-         z(i)=0.d0
-         vx(i)=0.d0
-         vy(i)=0.d0
-         vz(i)=0.d0
-         gx(i)=0.d0
-         gy(i)=0.d0
-         gz(i)=0.d0
-         vxdot(i)=0.d0
-         vydot(i)=0.d0
-         vzdot(i)=0.d0
-         u(i)=0.d0
-         udot(i)=0.d0
-         if(hco.gt.0.d0) then
-            hp(i)=hco
-         else
-            hprms=0d0
-            do i=1,n1
-               hprms=hprms+hp(i)**2
-            enddo
-            hprms=sqrt(hprms/n1)
-            if(myrank.eq.0) then
-               write(69,*) 'rms smoothing length h in star=',hprms
+     $        ' does not exist: will use'
+         if(.false.) then
+c     Second object will be a single compact object
+            if(myrank.eq.0) write (69,*)
+     $           'compact object particle instead'
+            
+            n2=1
+            ntot=n1+n2
+            i=ntot
+            am2=mbh
+            am(i)=am2
+            x(i)=0.d0
+            y(i)=0.d0
+            z(i)=0.d0
+            vx(i)=0.d0
+            vy(i)=0.d0
+            vz(i)=0.d0
+            gx(i)=0.d0
+            gy(i)=0.d0
+            gz(i)=0.d0
+            vxdot(i)=0.d0
+            vydot(i)=0.d0
+            vzdot(i)=0.d0
+            u(i)=0.d0
+            udot(i)=0.d0
+            if(hco.gt.0.d0) then
+               hp(i)=hco
+            else
+               hp(i)=hprms
             endif
-            hp(i)=hprms
+            if(passivelyAdvected) then
+               aa(i)=hp(i)
+               bb(i)=0
+               dd(i)=0
+            endif
+            cc(i)=0
+            if(myrank.eq.0) write(69,*)'compact_object_mass',am(i)
+            if(myrank.eq.0) write(69,*)'compact_object_smoothing_length',
+     $           hp(i)
+         else
+c     Second object will be a compact object binary such as a binary black hole
+            if(myrank.eq.0) write (69,*)
+     $           'binary compact object instead'
+            n2=2
+            ntot=n1+n2
+            am(ntot-1)=bbh_m1
+            am(ntot)=bbh_m2
+            am2=bbh_m1+bbh_m2
+            do i=ntot-1,ntot
+               x(i)=0.d0
+               y(i)=0.d0
+               z(i)=0.d0
+               vx(i)=0.d0
+               vy(i)=0.d0
+               vz(i)=0.d0
+               gx(i)=0.d0
+               gy(i)=0.d0
+               gz(i)=0.d0
+               vxdot(i)=0.d0
+               vydot(i)=0.d0
+               vzdot(i)=0.d0
+               u(i)=0.d0
+               udot(i)=0.d0
+               if(hco.gt.0.d0) then
+                  hp(i)=hco
+               else if (u(1).eq.0) then
+                  hp(i)=hp(1) ! If first point is core point, use same softening
+               else
+                  hp(i)=hprms
+               endif
+               if(passivelyAdvected) then
+                  aa(i)=hp(i)
+                  bb(i)=0
+                  dd(i)=0
+               endif
+               cc(i)=0
+               if(myrank.eq.0) write(69,*)'compact_object_mass',
+     $              am(i),'i=',i
+               if(myrank.eq.0) write(69,*)
+     $              'compact_object_smoothing_length',hp(i),
+     $              'i=',i
+            enddo
+
+            k=bbh_m1*bbh_m2
+            mu=k/(bbh_m1+bbh_m2)
+
+            if(bbh_rp.lt.0d0 .and. bbh_semimajoraxis.eq.0.d0)then
+c     presumably bbh_e0 and bbh_vinf2 have been set in sph.input:
+               eorb0=0.5d0*mu*bbh_vinf2
+               bbh_semimajoraxis=-0.5d0*k/eorb0
+               rp=bbh_semimajoraxis*(1.d0-bbh_e0)
+            else if(bbh_vinf2.ge.1d30 .and. bbh_semimajoraxis.eq.0.d0)then
+c     presumably bbh_e0 and bbh_rp have been set in sph.input:
+               bbh_semimajoraxis=bbh_rp/(1.d0-bbh_e0)
+               eorb0=-0.5d0*k/bbh_semimajoraxis
+               bbh_vinf2=2.d0*eorb0/mu
+            else if(bbh_vinf2.ge.1d30 .and. bbh_e0.lt.0.d0)then
+c     presumably bbh_semimajoraxis and bbh_rp have been set in sph.input:
+               eorb0=-0.5d0*k/bbh_semimajoraxis
+               bbh_vinf2=2.d0*eorb0/mu
+               bbh_e0=1.d0-bbh_rp/bbh_semimajoraxis
+            else if(bbh_rp.lt.0.d0 .and. bbh_vinf2.ge.1.d30)then
+c     presumably bbh_semimajoraxis and bbh_e0 have been set in sph.input:
+               bbh_rp=bbh_semimajoraxis*(1.d0-bbh_e0)
+               eorb0=-0.5d0*k/bbh_semimajoraxis
+               bbh_vinf2=2.d0*eorb0/mu
+            else
+c     presumably bbh_rp and bbh_vinf2 have been set in sph.input:
+               eorb0=0.5d0*mu*bbh_vinf2
+               bbh_semimajoraxis=-0.5d0*k/eorb0
+               bbh_e0=1.d0-bbh_rp/bbh_semimajoraxis
+            endif
+
+            if(myrank.eq.0) then
+               write(69,*) 'hyperbolic: bbh_rp=',
+     $              bbh_rp,'bbh_v_inf2=',bbh_vinf2,'bbh_semimajoraxis=',
+     $              bbh_semimajoraxis
+               write(69,*)'hyperbolic: bbh_e_orb=',eorb0
+               write(69,*)'hyperbolic: n=',n,'ntot=',ntot
+            endif
+            
+            semilatusrectum=bbh_rp*(1.d0+bbh_e0)
+            
+c     equation (8.41) of marion and thornton
+c            costheta = (semilatusrectum/bbh_sep0-1.d0)/bbh_e0
+            theta=bbh_trueanomaly ! true anomaly should be from -pi to +pi
+            costheta=cos(theta)
+            bbh_sep0=semilatusrectum/(1d0+bbh_e0*costheta)
+            
+c     equation (8.40) of marion and thornton
+            ltot = sqrt(semilatusrectum*mu*k)
+c     equation (8.10) of marion and thornton
+            thetadot = ltot/mu/bbh_sep0**2
+c     equation (8.40) of marion and thornton
+            eorb0check = (bbh_e0**2-1.d0)*mu*k*k/(ltot*ltot)*0.5d0
+            if(myrank.eq.0) write(69,*)'1st simple bbh check:',
+     $           eorb0,eorb0check
+            
+            sintheta = sin(theta)
+            sinthetacheck = sqrt(1.d0-costheta**2)
+            if( abs(abs(sintheta)-sinthetacheck ).gt.1.d-13) then
+               write(69,*)'2nd simple bbh check fails',sintheta,sinthetacheck
+               stop
+            endif
+            if(myrank.eq.0) write(69,*)'bbh semilatusrectum=',
+     $           semilatusrectum,' bbh mu=',mu,
+     $           ' bbh_sep0=',bbh_sep0,' bbh_e0=',bbh_e0
+            if(myrank.eq.0) write(69,*) 'bbh cos=',costheta,
+     $           ' sin=',sintheta
+c     the minus signs on the position and velocity component equations
+c     have been chosen so that the separation vector r equals r2-r1,
+c     *not* r1-r2 as in marion and thornton.  this was done so that the
+c     code would give the same initial conditions as twostars.f when the
+c     eccentricity is 1
+            deltax1 = -bbh_m2/(bbh_m1+bbh_m2)*bbh_sep0*costheta
+            deltay1 = -bbh_m2/(bbh_m1+bbh_m2)*bbh_sep0*sintheta
+            deltax2 = bbh_m1/(bbh_m1+bbh_m2)*bbh_sep0*costheta
+            deltay2 = bbh_m1/(bbh_m1+bbh_m2)*bbh_sep0*sintheta
+c     differentiating eqn. 8.41
+            rdot=semilatusrectum/
+     $           (1.d0+bbh_e0*costheta)**2*bbh_e0*sintheta*thetadot
+c     another expr. for rdot (using eqn. 8.14) and compare
+            rdotcheck=sqrt((eorb0-0.5d0*ltot**2/mu/bbh_sep0**2+k/bbh_sep0)/
+     $           0.5d0/mu)
+            if(myrank.eq.0) write(69,*)
+     $           'bbh rdot(from semilatusrectum): ',rdot,
+     $           '  magnitude of bbh rdot(from e): ',rdotcheck
+c            if(rdot.ne.rdot)rdot=rdotcheck
+            deltavx1=bbh_m2/(bbh_m1+bbh_m2)*
+     $           (bbh_sep0*sintheta*thetadot-rdot*costheta)
+            deltavy1=bbh_m2/(bbh_m1+bbh_m2)*
+     $           (-bbh_sep0*costheta*thetadot-rdot*sintheta)
+            deltavx2=bbh_m1/(bbh_m1+bbh_m2)*
+     $           (-bbh_sep0*sintheta*thetadot+rdot*costheta)
+            deltavy2=bbh_m1/(bbh_m1+bbh_m2)*
+     $           (bbh_sep0*costheta*thetadot+rdot*sintheta)
+            if(myrank.eq.0) then 
+               write(69,*) 'compact object 1 starts with:'
+               write(69,*) '                     x=',deltax1,
+     $              ', y=',deltay1
+               write(69,*) '                    vx=',deltavx1,
+     $              ',vy=',deltavy1
+               write(69,*) 'compact object 2 starts with:'
+               write(69,*) '                     x=',deltax2,
+     $              ', y=',deltay2
+               write(69,*) '                    vx=',deltavx2,
+     $              ',vy=',deltavy2
+            endif
+            xcm=(bbh_m1*deltax1+bbh_m2*deltax2)/(bbh_m1+bbh_m2)
+            ycm=(bbh_m1*deltay1+bbh_m2*deltay2)/(bbh_m1+bbh_m2)
+            vxcm=(bbh_m1*deltavx1+bbh_m2*deltavx2)/(bbh_m1+bbh_m2)
+            vycm=(bbh_m1*deltavy1+bbh_m2*deltavy2)/(bbh_m1+bbh_m2)
+            if(myrank.eq.0) write(69,*)'bbh center of mass position:',
+     $           xcm,ycm
+            if(myrank.eq.0) write(69,*)'bbh center of mass velocity:',
+     $           vxcm,vycm
+            ak=bbh_m1*bbh_m2
+            mu=bbh_m1*bbh_m2/(bbh_m1+bbh_m2)
+            r = sqrt((deltax1-deltax2)**2 + (deltay1-deltay2)**2)
+            eorb0check = 0.5d0*(bbh_m1*(deltavx1**2+deltavy1**2) +
+     $           bbh_m2*(deltavx2**2+deltavy2**2)) - bbh_m1*bbh_m2/r
+            altotint = bbh_m1*(deltax1*deltavy1 - deltay1*deltavx1) +
+     $           bbh_m2*(deltax2*deltavy2 - deltay2*deltavx2)
+            e0check = sqrt(1.d0 + 2.d0*eorb0check*altotint**2/mu/ak**2)
+            semilatusrectumprime = r+bbh_e0*(deltax2-deltax1)
+            if(abs(r/bbh_sep0-1.d0).gt.1.d-8) then
+               write(69,*)'hyperbolic: bbh_sep0 problem',r,bbh_sep0
+               stop
+            endif
+            if(abs(eorb0check-eorb0).gt.1.d-8) then
+               write(69,*)'hyperbolic: bbh eorb0 problem',
+     $              eorb0check,eorb0
+               write(69,*)'Be sure to set two of bbh_semimajoraxis,',
+     $              'bbh_e0,bbh_vinf2,bbh_rp in sph.input'
+               stop
+            endif
+            if(abs(altotint/ltot-1.d0).gt.1.d-8) then
+               write(69,*)'hyperbolic: bbh angular momentum problem',
+     $              altotint,ltot
+               stop
+            endif
+            if(abs(e0check-bbh_e0).gt.1.d-7) then
+               write(69,*)'hyperbolic: bbh eccentricity problem',
+     $              e0check,bbh_e0
+               stop
+            endif
+            if(abs(semilatusrectumprime/semilatusrectum-1.d0).gt.1.d-8)then
+               write(69,*)'hyperbolic: bbh semilatusrectum problem',
+     $              semilatusrectumprime,semilatusrectum
+               stop
+            endif
+            if(bbh_vinf2.ge.0.d0) then
+               vinf=bbh_vinf2**0.5d0
+               if(myrank.eq.0) write(69,*)'bbh v_infinity=',vinf,
+     $              '(code units)=',
+     $              vinf*(gravconst*munit/runit)**0.5d0/1.d5,'km/s'
+               if(myrank.eq.0) write(69,*)'converted with velocity unit',
+     $              (gravconst*munit/runit)**0.5d0/1.d5,'km/s'
+            endif
+
+            do i=ntot-1,ntot
+C     Rotations as described here https://youtu.be/N_njPJYaXaU?t=1983
+c     First rotate around z-axis by the argument of periapsis
+               if(i.eq.ntot-1) then
+                  xold=deltax1
+                  yold=deltay1
+                  vxold=deltavx1
+                  vyold=deltavy1
+               else
+                  xold=deltax2
+                  yold=deltay2
+                  vxold=deltavx2
+                  vyold=deltavy2
+               endif
+               zold=0
+               vzold=0
+               xnew=cos(bbh_argperi)*xold-sin(bbh_argperi)*yold
+               ynew=sin(bbh_argperi)*xold+cos(bbh_argperi)*yold
+               znew=zold
+               vxnew=cos(bbh_argperi)*vxold-sin(bbh_argperi)*vyold
+               vynew=sin(bbh_argperi)*vxold+cos(bbh_argperi)*vyold
+               vznew=vzold
+c     Next rotate around y-axis by the inclination angle
+               xold=xnew
+               yold=ynew
+               zold=znew
+               vxold=vxnew
+               vyold=vynew
+               vzold=vznew
+               xnew=cos(bbh_inclination)*xold-sin(bbh_inclination)*zold
+               ynew=yold
+               znew=sin(bbh_inclination)*xold+cos(bbh_inclination)*zold
+               vxnew=cos(bbh_inclination)*vxold-sin(bbh_inclination)*vzold
+               vynew=vyold
+               vznew=sin(bbh_inclination)*vxold+cos(bbh_inclination)*vzold
+c     Finally rotate around z-axis by the longitude of ascending node
+               xold=xnew
+               yold=ynew
+               zold=znew
+               vxold=vxnew
+               vyold=vynew
+               vzold=vznew
+               x(i)=cos(bbh_longitude)*xold-sin(bbh_longitude)*yold
+               y(i)=sin(bbh_longitude)*xold+cos(bbh_longitude)*yold
+               z(i)=zold
+               vx(i)=cos(bbh_longitude)*vxold-sin(bbh_longitude)*vyold
+               vy(i)=sin(bbh_longitude)*vxold+cos(bbh_longitude)*vyold
+               vz(i)=vzold
+            enddo
+            
          endif
-         cc(i)=0
-         if(myrank.eq.0) write(69,*)'compact_object_mass',am(i)
-         if(myrank.eq.0) write(69,*)'compact_object_smoothing_length',
-     $        hp(i)
+         corepts=corepts+n2
       endif
       amthree=am2
+
 
 c     From energy conservation 0.5*vinf^2=0.5*vp^2-G*M/rp
 c     -> vinf^2=vp^2-2*G*M/rp
@@ -356,15 +648,13 @@ c     presumably (rp or impactparameter) and vinf2 have been set in sph.input:
       if(myrank.eq.0) then
          write(69,*) 'hyperbolic: impactparameter (if set)=',
      $        impactparameter,'v_inf2=',vinf2,'semimajoraxis=',semimajoraxis
-         write(69,*) 'hyperbolic: e_orb=',eorb0
-         write(69,*) 'hyperbolic: n=',n,'ntot=',ntot,'rp=',rp
-         write(69,*) 'hyperbolic: sep0 = ',sep0
-         write(69,*) 'hyperbolic: masses = ',am1,am2
+         write(69,*)'hyperbolic: e_orb=',eorb0
+         write (69,*)'hyperbolic: n=',n,'ntot=',ntot,'rp=',rp
          open(30,file='m1m2rp.sph')
 c     make file m1m2rp.sph with masses and radius in solar units
          write(30,*) n1,n2,rp
-         write(30,*) am1*munit/1.98843d33,am2*munit/1.98843d33,
-     $        rp*runit/6.9599d10     
+         write(30,*) am1*munit/1.9884098706980504d33,am2*munit/1.9884098706980504d33,
+     $        rp*runit/6.957d10     
          close(30)
       endif
 
@@ -384,7 +674,8 @@ c     equation (8.41) of marion and thornton
                write(69,*)'sep0 cannot be larger than',
      $              semilatusrectum/(1-e0)
             endif
-            write(69,*)'reset sep0=',sep0
+            write(69,*)'suggestion: reset sep0<=',sep0
+            sToP
          endif
       endif
 
@@ -404,8 +695,8 @@ c     equation (8.40) of marion and thornton
      $        abs(sintheta-sinthetacheck)
          stop
       endif
-      if(myrank.eq.0) write(69,*)'semilatusrectum=',semilatusrectum,' mu=',mu,
-     $     ' sep0=',sep0,' e0=',e0
+      if(myrank.eq.0) write(69,*)'semilatusrectum=',semilatusrectum,
+     $     ' mu=',mu,' sep0=',sep0,' e0=',e0
       if(myrank.eq.0) write(69,*) 'cos=',costheta,' sin=',sintheta
 c     the minus signs on the position and velocity component equations
 c     have been chosen so that the separation vector r equals r2-r1,
@@ -423,7 +714,7 @@ c     another expr. for rdot (using eqn. 8.14) and compare
       rdotcheck=-sqrt((eorb0-0.5d0*ltot**2/mu/sep0**2+k/sep0)/0.5d0/mu)
       if(myrank.eq.0) write(69,*) 'rdot(from semilatusrectum): ',rdot,
      $     '  rdot(from e): ',rdotcheck
-      if(rdot.ne.rdot)rdot=rdotcheck
+      if(rp.eq.0)rdot=rdotcheck
       deltavx1=am2/(am1+am2)*(sep0*sintheta*thetadot-rdot*costheta)
       deltavy1=am2/(am1+am2)*(-sep0*costheta*thetadot-rdot*sintheta)
       deltavx2=am1/(am1+am2)*(-sep0*sintheta*thetadot+rdot*costheta)

--- a/parallel_bleeding_edge/src/initialize_multiequalmass.f
+++ b/parallel_bleeding_edge/src/initialize_multiequalmass.f
@@ -14,7 +14,7 @@ c     creates a star with varying equalmass values, spanning from +1 along the +
      $     muarray(kdm),muarray2(kdm)
       real*8 egsol
 c     astronomical constants:
-      parameter(egsol=1.9891d+33)
+      parameter(egsol=1.9884098706980504d33)
 c     derived constants:
       real*8 integratednum
       common/splinestuff/rarray,uarray,muarray,rhoarray,

--- a/parallel_bleeding_edge/src/initialize_parent.f
+++ b/parallel_bleeding_edge/src/initialize_parent.f
@@ -14,7 +14,7 @@ c     creates a star from the data file yrec output
      $     muarray(kdm),muarray2(kdm)
       real*8 egsol
 c     astronomical constants:
-      parameter(egsol=1.9891d+33)
+      parameter(egsol=1.9884098706980504d33)
 c     derived constants:
       real*8 integratednum
       common/splinestuff/rarray,uarray,muarray,rhoarray,
@@ -50,7 +50,7 @@ c     derived constants:
       rhomax=rhoarray(1)
       if(myrank.eq.0)write(69,*)'maximum central density=',rhomax
 
-      if(myrank.eq.0)write(69,*)'85 percent radius redge1=',redge1
+      if(myrank.eq.0)write(69,*)'99 percent radius redge1=',redge1
 
       if(n.lt.0) then
             n=abs(n)*masscgs/egsol
@@ -61,8 +61,8 @@ c     derived constants:
          hc=0.5d0*radius*(1.3d0*nnopt/n)**(1.d0/3.d0) !trying to better estimate the nearest neighbor number... about 1.3*nnopt
       endif
 
-      redge2=radius-2.d0*hc
-      if(myrank.eq.0)write(69,*)'2h away from surface is redge2=',redge2
+      redge2=radius-1.5d0*hc
+      if(myrank.eq.0)write(69,*)'1.5h away from surface is redge2=',redge2
 
       redge=max(redge1,redge2)
       if(myrank.eq.0)write(69,*)'redge=max(redge1,redge2)=',redge
@@ -612,7 +612,7 @@ c     Read in a stellar evolution code file
      $     muarray(kdm),muarray2(kdm)
       real*8 egsol,solrad
 c     astronomical constants:
-      parameter(egsol=1.9891d+33,solrad=6.9599d10)
+      parameter(egsol=1.9884098706980504d33,solrad=6.957d10)
 c     derived constants:
       integer ndim
       parameter(ndim=9)
@@ -628,8 +628,8 @@ c     derived constants:
       real*8 redge1
       real*8 amass1,amass2
       common/forcompbest/ amass1,amass2
-      real*8 temperaturefunction
-      external temperaturefunction
+      real*8 temperaturefunction,temperaturefunction2
+      external temperaturefunction,temperaturefunction2
       real*8 ufunction,useeostable,temupperlimit,uupperlimit
       external ufunction
       common/presarray/ pres,i
@@ -657,15 +657,28 @@ c     derived constants:
      $     ilogRho,ilogP,ix_mass_fraction_H,iy_mass_fraction_He,
      $     iz_mass_fraction_metals,ih1,ihe3,ihe4
       real*8 mesadata(2:maxnumcol)
+      integer lenp
+
+      lenp = len(trim(profilefile))
+      if (lenp .ge. 4) then
+         if (profilefile(lenp-3:lenp) .eq. '.asc') then
+            stellarevolutioncodetype = 2 ! Freitag and Benz
+         elseif (profilefile(lenp-3:lenp) .eq. 'data') then
+            stellarevolutioncodetype = 1 ! MESA
+         elseif (profilefile(lenp-3:lenp) .eq. 's2mm') then
+            stellarevolutioncodetype = 0 ! TWIN
+         endif
+      endif
 
       if(myrank.eq.0) then
          write(69,*) 'splinesetup: stellarevolutioncodetype=',
      $        stellarevolutioncodetype
          write(69,*) '             about to read file ',trim(profilefile)
       endif
+
  10   open(io,file=profilefile,status='old')
       if(stellarevolutioncodetype.eq.0) then
-c     This is a *.s2mm file made by TWIN on starsmasher.allegheny.edu
+c     This is a *s2mm file made by TWIN on starsmasher.allegheny.edu
 c     h, he4 , c12, n14, o16, ne20
          ln(1)=0
          ln(2)=2
@@ -750,6 +763,48 @@ c     get profiles:
             maxmu=max(maxmu,muarray(i))
             minmu=min(minmu,muarray(i))
          enddo
+      else if(stellarevolutioncodetype.eq.2) then
+c     This is a *si.asc file used by Freitag and Benz
+
+c     skip over the first 6 lines of header information:
+         do k=1,6
+            read(io,*)
+         enddo
+c     get profiles:
+         i=0
+         do k=1,kdm
+            i=i+1
+            read(io,*, end=23) rarray(i),uarray(i),rhoarray(i),muarray(i),xm(i)
+            rarray(i)=rarray(i)*solrad
+            uarray(i)=uarray(i)*gravconst*egsol/solrad
+            rhoarray(i)=rhoarray(i)*egsol/solrad**3
+            muarray(i)=muarray(i)*1.67262158d-24
+            xm(i)=xm(i)*egsol
+            tem(i)=zeroin(0.d0,uarray(i)*muarray(i)/boltz,
+     $           temperaturefunction2,1.d-11)
+            pres(i)=rhoarray(i)*boltz*tem(i)/muarray(i)+1d0/3*arad*tem(i)**4
+c            if(myrank.eq.0) then
+c               write(69,*) 'check',i,tem(i)
+c               tem(i)=zeroin(0.d0,pres(i)*muarray(i)/(rhoarray(i)*boltz),
+c     $              temperaturefunction,1.d-11)
+c               write(69,*) tem(i)
+c            endif
+            if(i.gt.1 .and. rarray(i).le.rarray(i-1)) then
+               if(myrank.eq.0) write(69,*)'ignoring shell',k
+               i=i-1
+            endif
+
+         enddo
+         if(myrank.eq.0)write(69,*)'need to increase kdm'
+         stop
+ 23      close(io)
+
+         numlines=i-1
+         xm(numlines+1)=xm(numlines)
+         rarray(numlines+1)=rarray(numlines)
+         pres(numlines+1)=0.d0
+         rhoarray(numlines+1)=0.d0
+         if(myrank.eq.0)write(69,*)'number of shells=',numlines
       else if(stellarevolutioncodetype.eq.1) then
 c     profilefile comes from MESA
          read(io,*,err=22) one  ! It's safe to ignore a compiler warning here
@@ -768,13 +823,6 @@ c     profilefile comes from MESA
          read(io,*)             ! read past all the global data... we'll read this in later
          read(io,*)             ! blank line
          
-         
-
-
-
-
-
-
          do i=1,maxnumcol
             in(i)=0
          enddo
@@ -868,7 +916,6 @@ c     profilefile comes from MESA
             write(69,*) ihe4,' : X_He4'
          endif
 
-
          if(myrank.eq.0) then
             write(69,*)'model_number=',model_number            
             write(69,*)'num_zones=',num_zones                  
@@ -916,21 +963,21 @@ c     $           z_mass_fraction_metals, (dummy, ii=1,26),xm(i)
                stop
             endif
 
-            xm(i)=xm(i)*1.9892d33
+            xm(i)=xm(i)*1.9884098706980504d33
 
 c            read(io,*) zone, qq, logR, logRho, logT, logP, logPgas,             
 c     $           luminosity,x_mass_fraction_H,y_mass_fraction_He,             
 c     $           z_mass_fraction_metals,gamma1,opacity,pp,cno,gradr,
 c     $           gradT,grada,actual_gradT,total_energy,
 c     $           total_energy_integral,scale_height,mu           
-c            xm(i)=star_mass*qq*1.9892d33     
+c            xm(i)=star_mass*qq*1.9884098706980504d33     
 
             if(k.eq.1 .and. myrank.eq.0) then
                write(69,*) 'Surface x,y,z=',x_mass_fraction_H,
      $              y_mass_fraction_He,z_mass_fraction_metals
             endif
 
-            rarray(i)=10d0**logR*6.9598d10
+            rarray(i)=10d0**logR*6.957d10
             if(i.lt.num_zones .and. rarray(i+1).le.rarray(i)) then             
                write(69,*)'ignoring shell',k
                stop      
@@ -1069,7 +1116,7 @@ c            write(102,*) i,uarray(i),tem(i)
      $     write(69,*)'total mass=',xm(numlines),xm(numlines)/egsol
 
       do i=1,numlines
-         if(xm(i).gt.0.85d0*masscgs) then
+         if(xm(i).gt.0.99d0*masscgs) then
             redge1=rarray(i)/runit
             goto 143
          endif

--- a/parallel_bleeding_edge/src/initialize_rescale.f
+++ b/parallel_bleeding_edge/src/initialize_rescale.f
@@ -15,7 +15,7 @@ c     creates a star with varying equalmass values, spanning from +1 along the +
      $     muarray(kdm),muarray2(kdm)
       real*8 egsol
 c     astronomical constants:
-      parameter(egsol=1.9891d+33)
+      parameter(egsol=1.9884098706980504d33)
 c     derived constants:
       real*8 integratednum
       common/splinestuff/rarray,uarray,muarray,rhoarray,

--- a/parallel_bleeding_edge/src/initialize_smbh.f
+++ b/parallel_bleeding_edge/src/initialize_smbh.f
@@ -15,7 +15,7 @@
       character*7 dummy
       real*8 am1chk,am2chk,am3chk
       real*8 egsol,solrad
-      parameter(egsol=1.9891d+33,solrad=6.9599d10)
+      parameter(egsol=1.9884098706980504d33,solrad=6.957d10)
       real*8 au
       parameter(au=14959787066000.d0)
       real*8 displacex, displacey,displacez

--- a/parallel_bleeding_edge/src/initialize_triple.f
+++ b/parallel_bleeding_edge/src/initialize_triple.f
@@ -15,7 +15,7 @@
       character*7 dummy
       real*8 am1chk,am2chk,am3chk
       real*8 egsol,solrad
-      parameter(egsol=1.9891d+33,solrad=6.9599d10)
+      parameter(egsol=1.9884098706980504d33,solrad=6.957d10)
       
       corepts=0
       write (69,*) 'triple: reading start files ...'

--- a/parallel_bleeding_edge/src/output.f
+++ b/parallel_bleeding_edge/src/output.f
@@ -248,6 +248,10 @@ c             else
 c              epot=epot+am(i)**2*42.d0/30.d0/hp(i) ! undo self-energy of point mass
 c             endif
             enddo
+            if (epot.eq.0) then
+               write(69,*) 'Problem calculating gravity: epot=0'
+               stop
+            endif
             epot=0.5d0*epot
          endif
       endif
@@ -469,11 +473,11 @@ c     so updating the entropy calculation is a low priority.
          
 c     append results of iteration to file:
          if(printingenergytofile)then
-            if (einit == 128.0) einit = etot
-            if (einit .eq. 0.0) then
-               print *, etot
-               stop 'error: einit = 0'
-            end if
+c            if (einit == 128.0) einit = etot
+c            if (einit .eq. 0.0) then
+c               print *, etot
+c               stop 'error: einit = 0'
+c            end if
             if(nrelax.ge.2)then
                call getcoms
                write(69,*)'separation=',

--- a/parallel_bleeding_edge/src/starsmasher.h
+++ b/parallel_bleeding_edge/src/starsmasher.h
@@ -22,7 +22,7 @@
       real*8 wtab(ntab),dwtab(ntab),ctab,dwdhtab(ntab),dphidhtab(ntab)
       real*8 x(nmax),y(nmax),z(nmax),vx(nmax),vy(nmax),vz(nmax)  
       real*8 am(nmax),hp(nmax),u(nmax),rho(nmax),por2(nmax)
-      real*8 grpot(nmax),meanmolecular(nmax)
+      real*8 grpot(nmax),meanmolecular(nmax),bb(nmax),aa(nmax),dd(nmax)
       real*8 zeta(nmax),bonet_omega(nmax), bonet_0mega(nmax) 
       real*8 bonet_psi(nmax), bonet_wn(nmax), max_vsig(nmax)
       real*8 vxdot(nmax),vydot(nmax),vzdot(nmax),udot(nmax)
@@ -42,7 +42,7 @@
       parameter(sigma=pi**2*boltz*(boltz*2d0*pi/planck)**3/60d0/crad2)
       parameter(arad=4.0d0*sigma/crad,qconst=1.5d0*boltz/arad)
       real*8 munit,runit,punit,gravconst,redge
-      parameter(gravconst = 6.67390d-08)
+      parameter(gravconst = 6.67430d-08)
       common/units/munit,runit,punit
       common/artvis/ alpha,beta,nav
       integer computeexclusivemode,ppn

--- a/parallel_bleeding_edge/src/temperaturefunction.f
+++ b/parallel_bleeding_edge/src/temperaturefunction.f
@@ -1,5 +1,6 @@
       double precision function temperaturefunction(temi)
-
+c     temperaturefunction will equal zero when the input temperature T=temi
+c     satisfies P=rho*k*T/mu + 1/3 aT^4
       include 'starsmasher.h'
       real*8 rhoarray(kdm),uarray(kdm),rarray(kdm),
      $     muarray(kdm),pres(kdm)
@@ -10,6 +11,23 @@
 
       temperaturefunction=1.d0-(rhoarray(i)*boltz*temi/muarray(i)
      $     +arad*temi**4/3.d0)/pres(i)
+
+      return
+      end
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      double precision function temperaturefunction2(temi)
+c     temperaturefunction2 will equal zero when the input temperature T=temi
+c     satisfies u=3/2 k*T/mu + aT^4/rho
+      include 'starsmasher.h'
+      real*8 rhoarray(kdm),uarray(kdm),rarray(kdm),
+     $     muarray(kdm),pres(kdm)
+      integer i
+      real*8 temi
+      common/splinestuff/rarray,uarray,muarray,rhoarray
+      common/presarray/ pres,i
+
+      temperaturefunction2=1.d0-(1.5d0*boltz*temi/muarray(i)
+     $     +arad*temi**4/rhoarray(i))/uarray(i)
 
       return
       end

--- a/parallel_bleeding_edge/src/tstep.f
+++ b/parallel_bleeding_edge/src/tstep.f
@@ -36,7 +36,9 @@ c***********************************************************************
 
       do i=n_lower,n_upper
          if(u(i).ne.0.d0) then
-            dtivel=cn1*hp(i)/sqrt(uijmax(i))
+c            dtivel=cn1*hp(i)/sqrt(uijmax(i))
+            dtivel=cn1*hp(i)/sqrt(max(uijmax(i),
+     $           (vx(i)**2+vy(i)**2+vz(i)**2)/16))
             dtiacc=cn2*hp(i)**0.5d0/((vxdot(i)-vxdotsm(i))**2
      $           +(vydot(i)-vydotsm(i))**2
      $           +(vzdot(i)-vzdotsm(i))**2)**0.25d0


### PR DESCRIPTION
These changes accumulated in the maintainer's working tree between November 2024 and August 2026 without being committed. This lands them as a single commit. No attempt is made to reconstruct the intermediate history.

Physics and initial conditions:
- initialize_hyperbolic.f: add binary-black-hole orbital element handling (bbh_m1, bbh_m2, bbh_rp, bbh_semimajoraxis, bbh_vinf2), so a compact-object companion can be specified by orbital elements
- initialize_parent.f, init.f, changetf.f, compbest3.f: assorted fixes
- initialize_asciiimage.f, output.f, temperaturefunction.f, tstep.f: updates to diagnostics and timestep control
- starsmasher.h: update gravconst to the CODATA 2018 value (6.67430d-08, was 6.67390d-08)

Build:
- SPHgrav_lib2: update grav_force_direct.cu and its Makefile

Notes:
- aa/bb/dd are sized nmax rather than 1 so that if the analytic equation that determines smoothing length from particle density is being implemented, then this can be done with coefficients determined on a particle-by-particle basis (rather than using the same coefficients in that equation for all particles)
- The main src/Makefile is intentionally untouched; see PR #7.

Verified: builds and links clean with gfortran 14.3 / OpenMPI / CUDA 13.3 at nmax=900000, GPU path included.