### PR TITLE
Guard against MESA profiles with more than kdm zones

### DIFF
--- a/parallel_bleeding_edge/src/initialize_parent.f
+++ b/parallel_bleeding_edge/src/initialize_parent.f
@@ -855,18 +855,23 @@ c     profilefile comes from MESA
      $        c_core_mass,o_core_mass,si_core_mass,fe_core_mass,             
      $        neutron_rich_core_mass
      
-         if((num_zones .gt. kdm).and.(myrank .eq. 0)) then
-              print *, "Too many zones in the MESA profile!"
-              print *, "Edit the value of 'kdm' in starsmasher.h to use"//
-     $             " more."
-              print *, "num_zones = ",num_zones
-              print *, "Max allowed zones kdm = ", kdm
-              write(69,*) "Too many zones in the MESA profile!"
-              write(69,*) "Edit the value of 'kdm' in starsmasher.h to "//
-     $             "use more."
-              write(69,*) "num_zones = ",num_zones
-              write(69,*) "Max allowed zones kdm = ", kdm
-              error stop
+         if(num_zones .gt. kdm) then
+c     Every rank must take this branch: the read loop below is bounded by
+c     num_zones, not by kdm, so any rank that continues past this point
+c     writes past the end of the kdm-sized profile arrays.
+            if(myrank .eq. 0) then
+               print *, "Too many zones in the MESA profile!"
+               print *, "Edit the value of 'kdm' in starsmasher.h to "//
+     $              "use more, then rebuild."
+               print *, "num_zones = ",num_zones
+               print *, "Max allowed zones kdm = ", kdm
+               write(69,*) "Too many zones in the MESA profile!"
+               write(69,*) "Edit the value of 'kdm' in starsmasher.h "//
+     $              "to use more, then rebuild."
+               write(69,*) "num_zones = ",num_zones
+               write(69,*) "Max allowed zones kdm = ", kdm
+            end if
+            error stop
          end if
      
          read(io,*)             ! blank line

--- a/parallel_bleeding_edge/src/initialize_parent.f
+++ b/parallel_bleeding_edge/src/initialize_parent.f
@@ -854,6 +854,21 @@ c     profilefile comes from MESA
      $        star_mass_n14,star_mass_o16,star_mass_ne20,he_core_mass,       
      $        c_core_mass,o_core_mass,si_core_mass,fe_core_mass,             
      $        neutron_rich_core_mass
+     
+         if((num_zones .gt. kdm).and.(myrank .eq. 0)) then
+              print *, "Too many zones in the MESA profile!"
+              print *, "Edit the value of 'kdm' in starsmasher.h to use"//
+     $             " more."
+              print *, "num_zones = ",num_zones
+              print *, "Max allowed zones kdm = ", kdm
+              write(69,*) "Too many zones in the MESA profile!"
+              write(69,*) "Edit the value of 'kdm' in starsmasher.h to "//
+     $             "use more."
+              write(69,*) "num_zones = ",num_zones
+              write(69,*) "Max allowed zones kdm = ", kdm
+              error stop
+         end if
+     
          read(io,*)             ! blank line
          read(io,*)             ! list of integers                   
 


### PR DESCRIPTION
Supersedes #2. The guard commit here is @hatfullr's original work, cherry-picked
with authorship intact; the second commit fixes a flaw in it.

### The bug

In `splinesetup`, every MESA profile array is dimensioned `kdm` (5000):

```fortran
real*8 tem(kdm), pres(kdm), rhoarray(kdm), uarray(kdm), rarray(kdm),
       rhoarray2(kdm), uarray2(kdm), xm(kdm), muarray(kdm), muarray2(kdm)
real*8 xx(ndim,kdm)
```

But the read loop takes its bound from the file, not from `kdm`:

```fortran
i = num_zones
do k = 1, num_zones
```

A MESA profile with more than 5000 zones therefore writes past the end of all
eleven arrays, beginning with the very first write at index `num_zones`. Modern
MESA models routinely carry 10,000–20,000 zones, so this is easy to hit — it is
what @hatfullr ran into in 2018.

Worth noting the contrast: the non-MESA read path in the same file is already
guarded correctly. It loops `do k=1,kdm` and, if it runs out of room, prints
`'need to increase kdm'` and stops. Only the MESA path lacked that protection.

### The fix to the fix

@hatfullr's guard combined two unrelated conditions:

```fortran
if((num_zones .gt. kdm).and.(myrank .eq. 0)) then
   ...
   error stop
end if
```

Only rank 0 satisfies `myrank .eq. 0`, so only rank 0 reached the `error stop`.
Every other rank skipped the block and continued into the read loop — overrunning
exactly the arrays the check was meant to protect. In practice `error stop` on one
rank usually causes the MPI runtime to tear down the job, so it would often
terminate anyway, but that relies on runtime behaviour and on losing a race.

The second commit tests the bound on every rank and restricts only the diagnostic
output to rank 0.

### Why this does not raise `kdm`

#2 also raised `kdm` from 5000 to 10000. I have deliberately left that out, because
**it does not build at the default `nmax=900000`**:

```
bss at kdm=5000:    2039.9 MB   <- 8.1 MB of headroom
mcmodel=small cap:  2048.0 MB
bss at kdm=10000:   2063.8 MB   <- 15.8 MB over; ld fails with relocation overflow
```

Almost all of that comes from one place: `initialize_multiequalmass.f` declares
`rprearray(kdm,numangle)` and `rarray2(kdm,numangle)` with `numangle=301`. Those two
arrays are 602 of the 646 `kdm`-scaled doubles in the code, so doubling `kdm` adds
22.9 MB from them and only 1.7 MB from everything else combined.

Building with `-mcmodel=medium` resolves it (verified), but no Makefile in the tree
currently sets it, and the main `Makefile` is being rewritten in #7 — so that belongs
there rather than here. Raising `kdm` is worth doing, just not in this PR.

Note this also means the tree sits roughly 8 MB below a hard linker ceiling with
nothing guarding it: any future growth in static arrays will fail to link, with an
error that does not obviously point at the cause.

With this PR, a user with an oversized profile gets a clear message telling them to
raise `kdm`, instead of silent memory corruption.

### Verification

Builds and links clean — gfortran 14.3 / OpenMPI / CUDA 13.3, `nmax=900000`, GPU path
included. `bss` is 2039.9 MB, unchanged from master: the guard costs no memory.
