### PR TITLE
Clamp ngravprocs to the number of GPUs actually present

### DIFF
--- a/parallel_bleeding_edge/src/SPHgrav_lib2/grav_force_direct.cu
+++ b/parallel_bleeding_edge/src/SPHgrav_lib2/grav_force_direct.cu
@@ -538,9 +538,30 @@ struct SPHgrav_direct
 
   void setDevice(const int device)
   {
-    assert(device < ndevice);
-    assert(can_use_device[device]);
-    assert(cudaSetDevice(device) == cudaSuccess);
+    /* Report this rather than assert on it: an assertion here produces a bare
+       stack trace that gives no hint that the cause is a setting in sph.input,
+       and assertions vanish entirely if NDEBUG is ever defined. */
+    if (device < 0 || device >= ndevice)
+    {
+      fprintf(stderr,
+          "\n"
+          "StarSmasher: a process asked for GPU %d, but this node has only %d CUDA device%s.\n"
+          "  This almost always means ngravprocs in sph.input is larger than the number\n"
+          "  of GPUs available. Set ngravprocs to at most %d, or to -%d to request that\n"
+          "  many GPUs per node, or leave it at 0 to have it detected automatically.\n"
+          "\n",
+          device, ndevice, ndevice == 1 ? "" : "s", ndevice, ndevice);
+      fflush(stderr);
+      exit(EXIT_FAILURE);
+    }
+    const cudaError_t err = cudaSetDevice(device);
+    if (err != cudaSuccess)
+    {
+      fprintf(stderr, "\nStarSmasher: cudaSetDevice(%d) failed: %s\n\n",
+              device, cudaGetErrorString(err));
+      fflush(stderr);
+      exit(EXIT_FAILURE);
+    }
   }
 
   void first_half(const int nibeg, const int ni, const int nkernel)

--- a/parallel_bleeding_edge/src/init.f
+++ b/parallel_bleeding_edge/src/init.f
@@ -650,14 +650,14 @@ c     call execute_command_line('rm -f ' // trim(gpucfilename))
          endif
          call getenv('SLURM_GPUS_ON_NODE', slurm_gpu_count_str)
 !     Convert the string to an integer
-         read(slurm_gpu_count_str, '(I1)', IOSTAT=ierr) slurm_gpu_count
+         read(slurm_gpu_count_str, *, IOSTAT=ierr) slurm_gpu_count
 c         write(200+myrank,*) slurm_gpu_count, ierr
          if (ierr == 0 .and. slurm_gpu_count.gt.0) then
-            if(ngravprocs.eq.0 .or. ngravprocs.gt.slurm_gpu_count)then
+            if(ngravprocs.eq.0 .or. abs(ngravprocs).gt.slurm_gpu_count)then
                ngravprocs=-slurm_gpu_count
             endif
          else
-            if(ngravprocs.eq.0 .or. ngravprocs.gt.actual_gpu_count)then
+            if(ngravprocs.eq.0 .or. abs(ngravprocs).gt.actual_gpu_count)then
                ngravprocs=-actual_gpu_count
             endif
          endif


### PR DESCRIPTION
A new user following the installation guide and running the shipped relaxation_preMS example on more than one MPI rank got a segmentation fault and a C++ stack trace, with nothing to indicate that the cause was a setting in sph.input.

The example ships ngravprocs=-2. A negative ngravprocs means "this many GPUs per node", and main.f expands it to

    ngravprocs = min((nprocs+ppn-1)/ppn*abs(ngravprocs), nprocs)

with each gravity rank then taking device myrank/((nprocs+ppn-1)/ppn), so one GPU per gravity rank is assumed. init.f already counts the GPUs on the node and is meant to clamp ngravprocs to that count, but the test was

    if(ngravprocs.eq.0 .or. ngravprocs.gt.actual_gpu_count)

which ignores the negative convention it is written to guard. With one GPU and ngravprocs=-2, "-2 > 1" is false, no clamping happens, rank 1 asks for device 1, and the assertion in setDevice brings the job down. Compare magnitudes instead.

Two further changes in the same area:

- SLURM_GPUS_ON_NODE was parsed with format '(I1)', which reads a single digit and reports no error. On a node with 16 GPUs the value 16 was read as 1, silently confining the run to one GPU. Read it list-directed. This also makes an unset variable report an error rather than quietly yielding 0.

- setDevice asserted on the device index. An assertion gives a bare stack trace that points at the CUDA source rather than at the setting responsible. Report the mismatch, name ngravprocs as the likely cause, and exit.

Verified on one GPU (RTX 5080, CUDA 13.3) against the relaxation_preMS example. Before, np>1 with the shipped ngravprocs=-2 crashed; after, these all complete 439 iterations with total energy agreeing to seven significant figures:

    np=1 ngravprocs=-2      np=4 ngravprocs=-2      np=8 ngravprocs=-4
    np=2 ngravprocs=-2      np=4 ngravprocs=0       np=2 ngravprocs=1
                            np=4 ngravprocs=-1

Each is correctly reduced to ngravprocs=1, the number of GPUs present.