### PR TITLE
Combine CPU gravity with a sum, not a slice gather

### DIFF
--- a/parallel_bleeding_edge/src/initialize_multiequalmass.f
+++ b/parallel_bleeding_edge/src/initialize_multiequalmass.f
@@ -2,6 +2,7 @@
 c     creates a star with varying equalmass values, spanning from +1 along the +x-axis to -1 along the -x-axis.
       include 'starsmasher.h'
       include 'mpif.h'
+      real*8 grpottot(nmax)
       integer numlines,i
       integer idumb,ip,ix,iy,iz
       real*8 anumden,rhotry,rhoex,rtry,rhomax,hc,xcm,ycm,zcm,amtot,
@@ -489,6 +490,9 @@ c     do loop to get total gravitational potential energy:
                   call get_gravity_using_cpus
                endif
                if(ngravprocs.gt.1) then
+                  if(nusegpus.eq.1)then
+c     The gpu library returns a complete sum for every particle this rank
+c     owns, so gathering each rank's own slice is correct.
                   mygravlength=ngrav_upper-ngrav_lower+1
                   if(myrank.ne.0)then
                      call mpi_gatherv(grpot(ngrav_lower), mygravlength, mpi_double_precision,
@@ -498,6 +502,20 @@ c     do loop to get total gravitational potential energy:
                      call mpi_gatherv(mpi_in_place, mygravlength, mpi_double_precision,
      $                    grpot, gravrecvcounts, gravdispls, mpi_double_precision, 0,
      $                    comm_worker, ierr)
+                  endif
+                  else
+c     get_gravity_using_cpus walks pairs with j>=i, so a rank writes into
+c     grpot(j) for particles j it does not own.  A slice gather discards
+c     those contributions; the whole array must be summed instead.  This
+c     is what balAV3.f already does for the same reason.
+                     call mpi_reduce(grpot, grpottot, ntot,
+     $                    mpi_double_precision, mpi_sum, 0,
+     $                    mpi_comm_world, ierr)
+                     if(myrank.eq.0) then
+                        do i=1,ntot
+                           grpot(i)=grpottot(i)
+                        enddo
+                     endif
                   endif
                endif
             endif

--- a/parallel_bleeding_edge/src/initialize_parent.f
+++ b/parallel_bleeding_edge/src/initialize_parent.f
@@ -2,6 +2,7 @@
 c     creates a star from the data file yrec output
       include 'starsmasher.h'
       include 'mpif.h'
+      real*8 grpottot(nmax)
       integer numlines,i
       integer idumb,ip,ix,iy,iz
       real*8 anumden,rhotry,rhoex,rtry,rhomax,hc,xcm,ycm,zcm,amtot,
@@ -476,6 +477,9 @@ c     do loop to get total gravitational potential energy:
                   call get_gravity_using_cpus
                endif
                if(ngravprocs.gt.1) then
+                  if(nusegpus.eq.1)then
+c     The gpu library returns a complete sum for every particle this rank
+c     owns, so gathering each rank's own slice is correct.
                   mygravlength=ngrav_upper-ngrav_lower+1
                   if(myrank.ne.0)then
                      call mpi_gatherv(grpot(ngrav_lower), mygravlength, mpi_double_precision,
@@ -485,6 +489,20 @@ c     do loop to get total gravitational potential energy:
                      call mpi_gatherv(mpi_in_place, mygravlength, mpi_double_precision,
      $                    grpot, gravrecvcounts, gravdispls, mpi_double_precision, 0,
      $                    comm_worker, ierr)
+                  endif
+                  else
+c     get_gravity_using_cpus walks pairs with j>=i, so a rank writes into
+c     grpot(j) for particles j it does not own.  Those contributions are
+c     thrown away by a slice gather; the whole array has to be summed.
+c     This is what balAV3.f does for the same reason.
+                     call mpi_reduce(grpot, grpottot, ntot,
+     $                    mpi_double_precision, mpi_sum, 0,
+     $                    mpi_comm_world, ierr)
+                     if(myrank.eq.0) then
+                        do i=1,ntot
+                           grpot(i)=grpottot(i)
+                        enddo
+                     endif
                   endif
                endif
             endif

--- a/parallel_bleeding_edge/src/initialize_polyes.f
+++ b/parallel_bleeding_edge/src/initialize_polyes.f
@@ -2,6 +2,7 @@
 c     creates a star from the data file yrec output
       include 'starsmasher.h'
       include 'mpif.h'
+      real*8 grpottot(nmax)
       integer i
       integer ntry,idumb,ip,ix,iy,iz,maxtry
       parameter(maxtry=300000000)
@@ -436,6 +437,9 @@ c     do loop to get total gravitational potential energy:
                   call get_gravity_using_cpus
                endif
                if(ngravprocs.gt.1) then
+                  if(nusegpus.eq.1)then
+c     The gpu library returns a complete sum for every particle this rank
+c     owns, so gathering each rank's own slice is correct.
                   mygravlength=ngrav_upper-ngrav_lower+1
                   if(myrank.ne.0)then
                      call mpi_gatherv(grpot(ngrav_lower), mygravlength, mpi_double_precision,
@@ -445,6 +449,20 @@ c     do loop to get total gravitational potential energy:
                      call mpi_gatherv(mpi_in_place, mygravlength, mpi_double_precision,
      $                    grpot, gravrecvcounts, gravdispls, mpi_double_precision, 0,
      $                    comm_worker, ierr)
+                  endif
+                  else
+c     get_gravity_using_cpus walks pairs with j>=i, so a rank writes into
+c     grpot(j) for particles j it does not own.  A slice gather discards
+c     those contributions; the whole array must be summed instead.  This
+c     is what balAV3.f already does for the same reason.
+                     call mpi_reduce(grpot, grpottot, ntot,
+     $                    mpi_double_precision, mpi_sum, 0,
+     $                    mpi_comm_world, ierr)
+                     if(myrank.eq.0) then
+                        do i=1,ntot
+                           grpot(i)=grpottot(i)
+                        enddo
+                     endif
                   endif
                endif
             endif

--- a/parallel_bleeding_edge/src/skipahead.f
+++ b/parallel_bleeding_edge/src/skipahead.f
@@ -1,6 +1,7 @@
       subroutine jumpahead
       include 'starsmasher.h'
       include 'mpif.h'
+      real*8 grpottot(nmax)
       real*8 am1,am2
       integer icomp(nmax)
       real*8 x1,y1,z1,vx1,vy1,vz1,x2,y2,z2,vx2,vy2,vz2,
@@ -74,6 +75,7 @@ c     Initializing bhcomp
          else
             call get_gravity_using_cpus
          endif
+         if(nusegpus.eq.1)then
          mygravlength=ngrav_upper-ngrav_lower+1
          if(myrank.ne.0)then
             call mpi_gatherv(grpot(ngrav_lower), mygravlength, mpi_double_precision,
@@ -83,6 +85,19 @@ c     Initializing bhcomp
             call mpi_gatherv(mpi_in_place, mygravlength, mpi_double_precision,
      $           grpot, gravrecvcounts, gravdispls, mpi_double_precision, 0,
      $           comm_worker, ierr)
+         endif
+         else
+c     get_gravity_using_cpus walks pairs with j>=i, so a rank writes
+c     into grpot(j) for particles it does not own.  A slice gather
+c     discards those; the whole array has to be summed instead.
+            call mpi_reduce(grpot, grpottot, ntot,
+     $        mpi_double_precision, mpi_sum, 0,
+     $        mpi_comm_world, ierr)
+            if(myrank.eq.0) then
+               do i=1,ntot
+                  grpot(i)=grpottot(i)
+               enddo
+            endif
          endif
       endif
       call enout(.false.)
@@ -567,6 +582,7 @@ c     would have happened:
          else
             call get_gravity_using_cpus
          endif
+         if(nusegpus.eq.1)then
          mygravlength=ngrav_upper-ngrav_lower+1
          if(myrank.ne.0)then
             call mpi_gatherv(grpot(ngrav_lower), mygravlength, mpi_double_precision,
@@ -576,6 +592,19 @@ c     would have happened:
             call mpi_gatherv(mpi_in_place, mygravlength, mpi_double_precision,
      $           grpot, gravrecvcounts, gravdispls, mpi_double_precision, 0,
      $           comm_worker, ierr) 
+         endif
+         else
+c     get_gravity_using_cpus walks pairs with j>=i, so a rank writes
+c     into grpot(j) for particles it does not own.  A slice gather
+c     discards those; the whole array has to be summed instead.
+            call mpi_reduce(grpot, grpottot, ntot,
+     $        mpi_double_precision, mpi_sum, 0,
+     $        mpi_comm_world, ierr)
+            if(myrank.eq.0) then
+               do i=1,ntot
+                  grpot(i)=grpottot(i)
+               enddo
+            endif
          endif
       endif
       call enout(.false.)
@@ -651,6 +680,7 @@ c     would have happened:
             else
                call get_gravity_using_cpus
             endif
+            if(nusegpus.eq.1)then
             mygravlength=ngrav_upper-ngrav_lower+1
             if(myrank.ne.0)then
                call mpi_gatherv(grpot(ngrav_lower), mygravlength, mpi_double_precision,
@@ -660,6 +690,19 @@ c     would have happened:
                call mpi_gatherv(mpi_in_place, mygravlength, mpi_double_precision,
      $              grpot, gravrecvcounts, gravdispls, mpi_double_precision, 0,
      $              comm_worker, ierr)
+            endif
+            else
+c     get_gravity_using_cpus walks pairs with j>=i, so a rank writes
+c     into grpot(j) for particles it does not own.  A slice gather
+c     discards those; the whole array has to be summed instead.
+               call mpi_reduce(grpot, grpottot, ntot,
+     $        mpi_double_precision, mpi_sum, 0,
+     $        mpi_comm_world, ierr)
+               if(myrank.eq.0) then
+                  do i=1,ntot
+                     grpot(i)=grpottot(i)
+                  enddo
+               endif
             endif
          endif
          call enout(.false.)


### PR DESCRIPTION
Self-gravity computed on CPUs was wrong whenever more than one MPI rank was used, and the error grew with the rank count. For the n=1.5 polytrope in example_input/relaxation_preMS, where theory gives W = -3/(5-n) M^2/R = -0.171429:

    ranks   W before      W after
      1     -0.171429     -0.171429
      2     -0.200147     -0.171429
      4     -0.240151     -0.171429

The GPU path was correct throughout. The results were wrong from t=0, so this affected the initial model rather than the integration.

The two gravity backends decompose the work differently. lasthalf_grav_forces returns a complete sum for every particle the rank owns, so gathering each rank's own slice reconstructs the whole array. get_gravity_using_cpus instead walks pairs with j>=i and accumulates into both grpot(i) and grpot(j), so a rank writes into particles it does not own, and the whole array has to be summed across ranks.

balAV3.f and eatem.f branch on nusegpus and do exactly that. The initialisation and jump-ahead paths did not: they chose the backend correctly and then combined the result with mpi_gatherv regardless, which is only valid for the gpu decomposition. Give them the same branch.

Fixed in initialize_polyes.f, initialize_parent.f, initialize_multiequalmass.f and skipahead.f.

Verified on the relaxation_preMS example, which exercises the initialize_polyes path: CPU and GPU builds now agree exactly at 1, 2 and 4 ranks, on W at t=0, on iteration count, and on final total energy. The other three files carry the identical pattern and the same reasoning, but I have not yet tried those code paths, so they are changed by inspection rather than by test.