### PR TITLE
Stop when the packed neighbour list runs out of room

### DIFF
--- a/parallel_bleeding_edge/src/advance.f90
+++ b/parallel_bleeding_edge/src/advance.f90
@@ -396,6 +396,7 @@
          call kdtree2_r_nearest_around_point(tp=tree2,idxin=i,correltime=-1,&
               r2=r2,nfound=cnt,nalloc=n,results=results)
          nn(i)=cnt
+         call check_neighbor_capacity(i)
          list(first(i)+1:first(i)+nn(i))=results(1:nn(i))%idx
          
          call bonetfuncd(i,fl,df)
@@ -434,6 +435,7 @@
                  correltime=-1,&
                  r2=r2,nfound=cnt,nalloc=n,results=results)
             nn(i)=cnt
+            call check_neighbor_capacity(i)
             list(first(i)+1:first(i)+nn(i))=results(1:nn(i))%idx
          endif
          r2last=r2
@@ -502,6 +504,7 @@
                     correltime=-1,r2=r2,nfound=cnt,nalloc=n,&
                     results=results)
                nn(i)=cnt
+               call check_neighbor_capacity(i)
                list(first(i)+1:first(i)+nn(i))=results(1:nn(i))%idx
             endif
             r2last=r2
@@ -559,6 +562,7 @@
                  correltime=-1,&
                  r2=r2,nfound=cnt,nalloc=n,results=results)
             nn(i)=cnt
+            call check_neighbor_capacity(i)
             list(first(i)+1:first(i)+nn(i))=results(1:nn(i))%idx
          endif
          
@@ -881,3 +885,40 @@
       return
       end
 
+
+!***********************************************************************
+      subroutine check_neighbor_capacity(i)
+!     The neighbour lists of all local particles are packed end to end into
+!     list(), which starsmasher.h dimensions as nnmax*nmax. Nothing in the
+!     kd-tree search bounds how many neighbours one particle may have, so a
+!     large nnopt or an unusually clustered configuration can run off the end
+!     of the array. Stop with an explanation instead of corrupting memory.
+      include 'starsmasher.h'
+      include 'mpif.h'
+      integer i,ierr
+
+      if(first(i)+nn(i).gt.nnmax*nmax) then
+         write(6,*)
+         write(6,*)'StarSmasher: neighbour list storage exhausted.'
+         write(6,*)'  rank                    =',myrank
+         write(6,*)'  particle                =',i
+         write(6,*)'  slots needed so far     =',first(i)+nn(i)
+         write(6,*)'  capacity (nnmax*nmax)   =',nnmax*nmax
+         write(6,*)'  nnopt                   =',nnopt
+         write(6,*)'  neighbours of this particle =',nn(i)
+         write(6,*)'Reduce nnopt in sph.input, or raise nnmax in'
+         write(6,*)'starsmasher.h and rebuild.'
+         write(6,*)
+         if(myrank.eq.0) then
+            write(69,*)'neighbour list storage exhausted:'
+            write(69,*)'  needed',first(i)+nn(i),' capacity',nnmax*nmax
+            write(69,*)'  at particle',i,' with nnopt=',nnopt
+            write(69,*)'  reduce nnopt, or raise nnmax and rebuild'
+         endif
+         call flush(6)
+         call mpi_abort(mpi_comm_world,1,ierr)
+         stop
+      endif
+
+      return
+      end


### PR DESCRIPTION
The neighbour lists of all local particles are packed end to end into list(), which starsmasher.h dimensions as nnmax*nmax:

    first(i) = first(i-1) + nn(i-1)
    list(first(i)+1 : first(i)+nn(i)) = results(1:nn(i))%idx

Nothing bounded that. nnmax appeared nowhere in the executable code, only in starsmasher.h where it sizes the array and in one commented-out line. The kd-tree search returns however many neighbours a particle has and the result was written into list() without checking that the packed total still fit, so a large nnopt, or a configuration clustered enough to push neighbour counts well above the intended average, would write past the end of the array and corrupt whatever followed it.

The bound is on the total rather than on any single particle: the layout is packed, so individual particles may exceed nnmax neighbours as long as the running sum stays within nnmax*nmax.

Check the running total before each write and stop with the numbers involved and what to change. The check has to precede the write, since afterwards the corruption has already happened and the counters used to detect it may themselves have been overwritten. Only one of the four call sites executes per particle, so the cost is a single integer comparison per particle per iteration, next to a kd-tree search that costs orders of magnitude more. mpi_abort brings every rank down together.

Verified by building with the capacity deliberately reduced:

    StarSmasher: neighbour list storage exhausted.
      rank                    =           0
      particle                =         565
      slots needed so far     =       20016
      capacity (nnmax*nmax)   =       20000
      nnopt                   =          23
      neighbours of this particle =          50

At the shipped limits the relaxation_preMS example is unaffected: 439 iterations and identical total energy on 1, 2 and 4 ranks.