### PR TITLE
Remove bimpact from the example input files

### DIFF
--- a/example_input/3_stars/sph.input
+++ b/example_input/3_stars/sph.input
@@ -3,7 +3,7 @@
  dtout=1, ! how often an out*.sph files should be dumped
  nrelax=0, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation in corotating frame with centrifugal and coriolis forces
  sep0=5, ! initial separation of two stars in a binary or collision calculation
- bimpact=2d0, ! the impact parameter for collisions; despite the name, this is actually the *periastron separation*
+ rp=2d0, ! periastron separation of initial Keplerian orbit
  e0=0.8d0, ! the semimajor axis for the collision (in units of runit below)
  ngravprocs=-1, ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
  computeexclusivemode=0, ! set this to 1 if on machine like grapefree with gpus in compute exclusive mode; set this to 0 on supercomputers like lincoln

--- a/example_input/Creating_a_MESA_star/sph.input
+++ b/example_input/Creating_a_MESA_star/sph.input
@@ -11,7 +11,6 @@
  nrelax=1, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation in corotating frame with centrifugal and coriolis forces
  trelax=1d30, ! timescale for artificial drag force.  keep it very large to turn off the drag force, which seems best even in relaxation runs (as the av can do the relaxation).
  sep0=20000, ! initial separation of two stars in a binary or collision calculation
- bimpact=1.d30, ! the impact parameter for collisions
  vinf2=1.d30, ! the speed squared at infinity for a collision between two stars: 0 for parabolic, >0 for hyperbolic, <0 for elliptical.
  equalmass=0, ! particle mass is proportional to rho^(1-equalmass), so equalmass=1 has equal mass particles and equalmass=0 is for constant number density.
  treloff=1, ! time to end a relaxation and switch to a dynamical calculation

--- a/example_input/collision_elliptical/sph.input
+++ b/example_input/collision_elliptical/sph.input
@@ -10,7 +10,7 @@
  nrelax=0, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation in corotating frame with centrifugal and coriolis forces
  trelax=1d30, ! timescale for artificial drag force.  keep it very large to turn off the drag force, which seems best even in relaxation runs (as the av can do the relaxation).
  sep0=150, ! initial separation of two stars in a binary or collision calculation
- bimpact=3.9d0, ! the impact parameter for collisions; despite the name, this is actually the *periastron separation*
+ rp=3.9d0, ! periastron separation of initial Keplerian orbit
  vinf2=-0.07d0, ! the speed squared at infinity for a collision between two stars: 0 for parabolic, >0 for hyperbolic, <0 for elliptical.
  equalmass=0, ! particle mass is proportional to rho^(1-equalmass), so equalmass=1 has equal mass particles and equalmass=0 is for constant number density.
  treloff=0, ! time to end a relaxation and switch to a dynamical calculation

--- a/example_input/corotating_binary/sph.input
+++ b/example_input/corotating_binary/sph.input
@@ -3,7 +3,6 @@
  dtout=1, ! how often an out*.sph files should be dumped
  nrelax=2, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation in corotating frame with centrifugal and coriolis forces
  sep0=5, ! initial separation of two stars in a binary or collision calculation
- bimpact=0.8d0, ! You don't need this, but you have to leave it there in way that your simulation is able to start
  e0=1.25d0, ! You don't need this, but you have to leave it there in way that your simulation is able to start
  ngravprocs=-1, ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
  computeexclusivemode=0, ! set this to 1 if on machine like grapefree with gpus in compute exclusive mode; set this to 0 on supercomputers like lincoln

--- a/example_input/oscillating_preMS/sph.input
+++ b/example_input/oscillating_preMS/sph.input
@@ -10,7 +10,6 @@
  nrelax=0, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation in corotating frame with centrifugal and coriolis forces
  trelax=1d30, ! timescale for artificial drag force.  keep it very large to turn off the drag force, which seems best even in relaxation runs (as the av can do the relaxation).
  sep0=20000, ! initial separation of two stars in a binary or collision calculation
- bimpact=1.d30, ! the impact parameter for collisions
  vinf2=1.d30, ! the speed squared at infinity for a collision between two stars: 0 for parabolic, >0 for hyperbolic, <0 for elliptical.
  equalmass=0, ! particle mass is proportional to rho^(1-equalmass), so equalmass=1 has equal mass particles and equalmass=0 is for constant number density.
  treloff=0, ! time to end a relaxation and switch to a dynamical calculation

--- a/example_input/relaxation_rotating_giant/sph.input
+++ b/example_input/relaxation_rotating_giant/sph.input
@@ -10,7 +10,6 @@
  nrelax=1, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation rotating frame with centrifugal and coriolis forces
  trelax=200, ! timescale for artificial drag force.  keep it very large to turn off the drag force, which seems best even in relaxation runs (as the av can do the relaxation).
  sep0=200, ! initial separation of two stars in a binary or collision calculation
- bimpact=1.d0, ! the impact parameter for collisions
  vinf2=0.0d0, ! the speed squared at infinity for a collision between two stars: 0 for parabolic, >0 for hyperbolic, <0 for elliptical.
  equalmass=0, ! particle mass is proportional to rho^(1-equalmass), so equalmass=1 has equal mass particles and equalmass=0 is for constant number density.
  treloff=10000, ! time to end a relaxation and switch to a dynamical calculation


### PR DESCRIPTION
Six of the ten examples could not be run. Their sph.input set bimpact, which is not in the input namelist, so the code stopped immediately with

    Fortran runtime error: Cannot match namelist object name bimpact

before doing anything at all. Affected were Creating_a_MESA_star, 3_stars, collision_elliptical, oscillating_preMS, corotating_binary and relaxation_rotating_giant. Creating_a_MESA_star is the one the installation guide sends new users to first.

Four of them never needed the variable.

The other two did need the quantity, and both said so themselves: the comment on each read "despite the name, this is actually the *periastron separation*". That is rp, which is already in the namelist, so they now set rp directly. The values are unchanged, and collision_elliptical now matches collision, which has always used rp=3.9d0 for the same orbit.

Tested by running each example from a copy of its own directory. Eight of the ten now run: 3_stars, collision, collision_elliptical, Creating_a_MESA_star, oscillating_preMS, relaxation_preMS, relaxation_rotating_giant and relaxation_TWIN_model.

Two still stop, for reasons that predate this change and are unaffected by it. corotating_binary needs sph.start1u and sph.start2u, the relaxed stars from an earlier run, which it does not ship. grsph fails while reading its own input. Both were verified against master, where corotating_binary stops earlier still, on the bimpact error.