### PR TITLE
Take the gravity library in Blackollider from parallel_bleeding_edge

### DIFF
--- a/Blackollider/src/SPHgrav_lib2/Makefile
+++ b/Blackollider/src/SPHgrav_lib2/Makefile
@@ -5,18 +5,23 @@ CC   := gcc
 AR   := ar ruv
 RANLIB := ranlib
 
-# path to your CUDA installation: CUDAPATH should contain the directory lib64 that contains libcudart.so as well as the bin directory that contains nvcc
+# Path to your CUDA installation: CUDAPATH should contain the directory lib64 that contains libcudart.so as well as the bin directory that contains nvcc
 CUDAPATH       := $(shell dirname $(shell dirname $(shell which nvcc)))
 CUDAINCLUDE    := -I$(CUDAPATH)/include
 NVCC           := $(CUDAPATH)/bin/nvcc
 
-# The 61 in the following line corresponds to a compute capability (version) of 6.1.  This value is specific to the
-# type of GPU to be used and likely will need to be changed.  Look at https://en.wikipedia.org/wiki/CUDA to find the
-# compute capability of your GPU.
-NVCCFLAGS := -arch=sm_61
-NVCCFLAGS += -O4 -g  $(CUDAINCLUDE)  -I./ -Xptxas -v ##########,-abi=no 
+# Automatically determine the compute capability of the GPU
+COMPUTE_CAPABILITY := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.')
 
-# NVCCFLAGS += -maxrregcount=32
+
+# Check if the capability is empty (no GPU detected) and set default value to 90 if so
+ifneq ($(COMPUTE_CAPABILITY),)
+    NVCCFLAGS := -arch=sm_$(COMPUTE_CAPABILITY)
+else
+    NVCCFLAGS := -arch=sm_89  # 5.2 for carrv122, 2.0 for gonzales, 6.1 for physics, 8.0 for a100, 9.0 for h100
+endif
+
+NVCCFLAGS += -O4 -g  $(CUDAINCLUDE)  -I./ -Xptxas -v ##########,-abi=no 
 NVCCFLAGS += -Xcompiler="-Wall"
 CUDA_LIBS = -L$(CUDAPATH)/lib64 -lcudart
 
@@ -30,17 +35,16 @@ GRAVLIB = libSPHgrav.a
 all: $(GRAVLIB)
 
 $(GRAVLIB): $(OBJS)
-	/bin/rm -f $@
-	$(AR) $@ $(OBJS)
+	    /bin/rm -f $@
+	    $(AR) $@ $(OBJS)
 
 .cpp.o: 
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 %.cu_o:  %.cu
-	$(NVCC) $(NVCCFLAGS) -c $< -o $@
+	 $(NVCC) $(NVCCFLAGS) -c $< -o $@
 
 clean:
 	/bin/rm -rf *.cu_o $(GRAVLIB)
 
 $(GRAVLIB): cutil.h cuVec3.h cuVector.h
-

--- a/Blackollider/src/SPHgrav_lib2/grav_force_direct.cu
+++ b/Blackollider/src/SPHgrav_lib2/grav_force_direct.cu
@@ -524,10 +524,12 @@ struct SPHgrav_direct
     {
       cudaDeviceProp p;
       assert(cudaGetDeviceProperties(&p, dev) == cudaSuccess);
+      int computeMode = -1;
+      cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, dev);
       const bool supported = p.major > 1 || (p.major == 1 && p.minor >= 3);
       if (rank == 0)
         fprintf(stderr,"  Device= %d: %s computeMode= %d computeCapability= %d_%d  supported= %s\n", 
-            dev, p.name, p.computeMode, p.major, p.minor, supported ? "YES" : "NO");
+            dev, p.name, computeMode, p.major, p.minor, supported ? "YES" : "NO");
       no_supported += supported ? 1 : 0;
       can_use_device[dev] = true;
     }
@@ -536,9 +538,30 @@ struct SPHgrav_direct
 
   void setDevice(const int device)
   {
-    assert(device < ndevice);
-    assert(can_use_device[device]);
-    assert(cudaSetDevice(device) == cudaSuccess);
+    /* Report this rather than assert on it: an assertion here produces a bare
+       stack trace that gives no hint that the cause is a setting in sph.input,
+       and assertions vanish entirely if NDEBUG is ever defined. */
+    if (device < 0 || device >= ndevice)
+    {
+      fprintf(stderr,
+          "\n"
+          "StarSmasher: a process asked for GPU %d, but this node has only %d CUDA device%s.\n"
+          "  This almost always means ngravprocs in sph.input is larger than the number\n"
+          "  of GPUs available. Set ngravprocs to at most %d, or to -%d to request that\n"
+          "  many GPUs per node, or leave it at 0 to have it detected automatically.\n"
+          "\n",
+          device, ndevice, ndevice == 1 ? "" : "s", ndevice, ndevice);
+      fflush(stderr);
+      exit(EXIT_FAILURE);
+    }
+    const cudaError_t err = cudaSetDevice(device);
+    if (err != cudaSuccess)
+    {
+      fprintf(stderr, "\nStarSmasher: cudaSetDevice(%d) failed: %s\n\n",
+              device, cudaGetErrorString(err));
+      fflush(stderr);
+      exit(EXIT_FAILURE);
+    }
   }
 
   void first_half(const int nibeg, const int ni, const int nkernel)


### PR DESCRIPTION
Blackollider's copy of SPHgrav_lib2 no longer builds against a current CUDA. Compiling it as shipped, with CUDA 13.3, stops immediately:

    nvcc fatal   : Unsupported gpu architecture 'sm_61'

because its Makefile hardcodes -arch=sm_61 and CUDA 13 has dropped that architecture. Correcting the architecture by hand only reaches the next failure:

    grav_force_direct.cu(530): error: class "cudaDeviceProp" has no
    member "computeMode"

computeMode was removed from cudaDeviceProp in CUDA 13.

Both problems were already solved in parallel_bleeding_edge, whose Makefile reads the compute capability from nvidia-smi and whose grav_force_direct.cu reads the compute mode through cudaDeviceGetAttribute. Rather than fix Blackollider separately, take those two files across unchanged, which also brings the clearer message that setDevice now prints when ngravprocs exceeds the number of GPUs present.

The two directories' copies of SPHgrav_lib2 are now identical in all five files; cutil.h, cuVec3.h and cuVector.h already were.

This matters for more than Blackollider users: section [2] of documentation/installation.md walks through the build using Blackollider as its example, so anyone following the installation guide on a recent CUDA hits the sm_61 error on the very first compile.

Verified by building Blackollider/src/SPHgrav_lib2 with CUDA 13.3 on a card of compute capability 12.0: the architecture is detected as sm_120 and libSPHgrav.a is produced.