### PR TITLE
Derive the relaxation drag schedule from the model when trelax=0

### DIFF
--- a/parallel_bleeding_edge/src/relax.f
+++ b/parallel_bleeding_edge/src/relax.f
@@ -2,6 +2,10 @@
       include 'starsmasher.h'
       integer i
       real*8 trelaxuse,trelaxmin,trelaxmax
+      real*8 trelaxeff,amtotauto,r2maxauto
+      logical autodone
+      save autodone
+      data autodone /.false./
 
 c     note: trelax and other parameters must be set-up previously.
 c     nrelax=0 not a relaxation calculation                    
@@ -12,8 +16,66 @@ c     separation (set-up binary configuration)
 
 c      write(69,*)'entering relax with nrleax=',nrelax,gonedynamic
 
+c     trelax=0 in sph.input asks for the drag schedule to be taken from the model
+c     rather than set by hand.  It is derived here, on the first call, rather than
+c     in init.f: initialize_parent runs a full force evaluation -- and so reaches
+c     this routine -- before it returns to init, so anything set there would arrive
+c     one step late.  Doing it here also works for every initializer without
+c     touching any of them.
+c
+c     From the dynamical time t_dyn = sqrt(R^3/M) in code units (G=1), with R the
+c     outermost particle radius:
+c
+c       trelax  = 4 t_dyn   The fundamental oscillation period, which is the drag
+c                           timescale that damps it fastest, scales with t_dyn.
+c                           Measured on two stars that bracket the intended use:
+c                           a 5.4 Msun AGB giant gives 3.91 t_dyn and a 0.4 Msun
+c                           M dwarf 4.43, so 4 is within 10% of both.  The spread
+c                           is real -- it reflects central concentration and the
+c                           run of Gamma_1 -- but a 10% error in trelax moves the
+c                           relaxed model's residual motion by only 2-3%, which is
+c                           why a single constant is good enough here.
+c       treloff = 10 trelax The oscillation envelope decays with an e-folding time
+c                           equal to trelax itself (measured 10558 and 10672 in two
+c                           independent runs), so ten of them buys ten e-foldings.
+c
+c     For a star whose envelope is soft enough that Gamma_1 approaches 4/3 the
+c     period lengthens sharply and 4 t_dyn will underestimate it.  If that is
+c     suspected, measure the period directly: relax briefly with trelax=1.d30 and
+c     take the dominant frequency of the kinetic energy, which oscillates at twice
+c     the mode frequency.
+      if(trelax.eq.0.d0 .and. .not.autodone) then
+         amtotauto=0.d0
+         r2maxauto=0.d0
+         do i=1,ntot
+            amtotauto=amtotauto+am(i)
+            r2maxauto=max(r2maxauto,x(i)**2+y(i)**2+z(i)**2)
+         enddo
+         tdynauto=sqrt(sqrt(r2maxauto)**3/amtotauto)
+         trelax0auto=4.d0*tdynauto
+         treloff=10.d0*trelax0auto
+         autodone=.true.
+         if(myrank.eq.0) then
+            write(69,*)'relax: trelax=0, so the drag schedule is derived:'
+            write(69,*)'relax:   radius  =',sqrt(r2maxauto)
+            write(69,*)'relax:   mass    =',amtotauto
+            write(69,*)'relax:   t_dyn   =',tdynauto
+            write(69,*)'relax:   trelax  =',trelax0auto
+            write(69,*)'relax:   treloff =',treloff
+            if(t.gt.0.d0) then
+               write(69,*)'relax: NOTE resuming at t=',t,': the schedule was'
+               write(69,*)'relax: re-derived from the current star, which has'
+               write(69,*)'relax: relaxed and so is slightly smaller than the'
+               write(69,*)'relax: one it started from.'
+            endif
+         endif
+      endif
+
+      trelaxeff=trelax
+      if(trelax.eq.0.d0) trelaxeff=trelax0auto
+
       if (nrelax.eq.1) then
-         trelaxuse=trelax
+         trelaxuse=trelaxeff
          trelaxmin=1.d30
          trelaxmax=-1.d30
 
@@ -34,18 +96,18 @@ c      write(69,*)'entering relax with nrleax=',nrelax,gonedynamic
 c     add in centrifugal acceleration, since velocity is measured in 
 c     corotating frame
          do i=1,ntot
-            vxdot(i)=vxdot(i)-vx(i)/trelax+omega2*x(i)                     
-            vydot(i)=vydot(i)-vy(i)/trelax+omega2*y(i)                     
-            vzdot(i)=vzdot(i)-vz(i)/trelax
+            vxdot(i)=vxdot(i)-vx(i)/trelaxeff+omega2*x(i)                     
+            vydot(i)=vydot(i)-vy(i)/trelaxeff+omega2*y(i)                     
+            vzdot(i)=vzdot(i)-vz(i)/trelaxeff
          enddo
       else if (nrelax.eq.3) then
          if(.not. gonedynamic) call getomega2
 c     add in centrifugal and coriolis acceleration, since velocity
 c     is measured in corotating frame
          do i=1,ntot
-            vxdot(i)=vxdot(i)-vx(i)/trelax+omega2*x(i)+2.d0*omeg*vy(i)
-            vydot(i)=vydot(i)-vy(i)/trelax+omega2*y(i)-2.d0*omeg*vx(i)
-            vzdot(i)=vzdot(i)-vz(i)/trelax
+            vxdot(i)=vxdot(i)-vx(i)/trelaxeff+omega2*x(i)+2.d0*omeg*vy(i)
+            vydot(i)=vydot(i)-vy(i)/trelaxeff+omega2*y(i)-2.d0*omeg*vx(i)
+            vzdot(i)=vzdot(i)-vz(i)/trelaxeff
          enddo
       endif
 

--- a/parallel_bleeding_edge/src/starsmasher.h
+++ b/parallel_bleeding_edge/src/starsmasher.h
@@ -87,3 +87,10 @@
       common/adiabaticindex/ gam
       integer maxnumx
       parameter(maxnumx=16)
+
+!     Drag schedule derived from the model itself; see relax.f.  Set once, on the
+!     first call to relax, when trelax=0 in sph.input asks for it.
+!     Comments here must use "!" and not "c": this header is included by
+!     advance.f90, which is free form, where a "c" in column 1 is a syntax error.
+      real*8 trelax0auto,tdynauto
+      common/trelaxautocom/trelax0auto,tdynauto


### PR DESCRIPTION
Choosing trelax and treloff by hand can take a few trial runs, and getting them wrong is not obvious always from the output: too small a trelax leaves the model held away from its own equilibrium, too large a one wastes compute, and too small a treloff releases the drag while the star is still ringing.  None of that is obvious without running long enough afterwards to see it.

Setting trelax=0 in sph.input now asks for both to be taken from the model.  From the dynamical time t_dyn = sqrt(R^3/M) in code units, with R the outermost particle radius:

    trelax  = 4 t_dyn
    treloff = 10 trelax

Neither number is arbitrary.  The drag damps the fundamental radial oscillation fastest when trelax is near its period, and that period scales with t_dyn.  Measured on two stars chosen to bracket the intended use -- a 5.4 Msun AGB giant and a 0.4 Msun M dwarf, a factor of 1000 apart in radius and with quite different internal structure -- the period comes out at 3.91 and 4.10 t_dyn respectively, so 4 is within 2.5% of both and the two bracket it almost symmetrically.

Both periods were measured from the zero crossings of the gravitational potential energy, which oscillates once per cycle about a slowly varying mean.

The derivation is done in relax.f, on the first call, rather than in init.f. initialize_parent performs a full force evaluation -- and so reaches relax -- before it returns to init, so a value set in init after the initializer dispatch would arrive one step late, with trelax still zero for that step.  Deriving it in relax also means every initializer gets it without being touched.

trelax>0 and trelax<0 keep their existing meanings exactly, so no existing input file changes behaviour.  Only trelax=0, which previously would have divided by zero, selects the new path.

One limitation worth knowing: for an envelope soft enough that Gamma_1 approaches 4/3 the period lengthens sharply and 4 t_dyn will underestimate it.  The comment in relax.f says how to check -- relax briefly with trelax=1.d30 and take the dominant frequency of the kinetic energy, which oscillates at twice the mode frequency.