### PR TITLE
Make the compute-capability detection harder to fool

### DIFF
--- a/parallel_bleeding_edge/src/SPHgrav_lib2/Makefile
+++ b/parallel_bleeding_edge/src/SPHgrav_lib2/Makefile
@@ -10,15 +10,23 @@ CUDAPATH       := $(shell dirname $(shell dirname $(shell which nvcc)))
 CUDAINCLUDE    := -I$(CUDAPATH)/include
 NVCC           := $(CUDAPATH)/bin/nvcc
 
-# Automatically determine the compute capability of the GPU
-COMPUTE_CAPABILITY := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.')
-
+# Automatically determine the compute capability of the GPU, in the undotted form
+# nvcc wants (12.0 -> 120).  Ask nvidia-smi first, then the query tool that ships
+# with CUDA, which reads the driver directly and still answers when nvidia-smi is
+# too old to know --query-gpu=compute_cap.  Keep only all-digit answers, so that a
+# warning printed on stdout ("Failed to initialize NVML: ...") cannot end up
+# inside the -arch flag.  With more than one GPU, take the lowest: code built for
+# a lower capability still runs on a higher card, because the driver recompiles
+# the embedded PTX at start-up, but not the other way round.
+COMPUTE_CAPABILITY := $(shell { nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | tr -d '.' ; \
+                                $(CUDAPATH)/bin/__nvcc_device_query 2>/dev/null ; echo ; } \
+                              | grep -x '[0-9][0-9]*' | sort -n | head -1)
 
 # Check if the capability is empty (no GPU detected) and set default value to 90 if so
 ifneq ($(COMPUTE_CAPABILITY),)
     NVCCFLAGS := -arch=sm_$(COMPUTE_CAPABILITY)
 else
-    NVCCFLAGS := -arch=sm_89  # 5.2 for carrv122, 2.0 for gonzales, 6.1 for physics, 8.0 for a100, 9.0 for h100
+    NVCCFLAGS := -arch=sm_90  # 80 for a100, 90 for h100
 endif
 
 NVCCFLAGS += -O4 -g  $(CUDAINCLUDE)  -I./ -Xptxas -v ##########,-abi=no 


### PR DESCRIPTION
The gravity library derived -arch=sm_NN from nvidia-smi and accepted whatever came back, testing only that the result was non-empty.  Anything nvidia-smi printed on stdout therefore reached the compiler.  After a driver update without a reboot it prints "Failed to initialize NVML: Driver/library version mismatch", which gave -arch=sm_Failed and a build that died with "nvcc fatal: Unsupported gpu architecture" -- a message pointing at the architecture when the problem is the driver.

Ask nvidia-smi first, then fall back to __nvcc_device_query, which ships with CUDA and reads the driver directly, so a machine whose nvidia-smi predates the compute_cap query field is now detected rather than sent to the default.  Keep only all-digit answers.  With more than one GPU take the lowest, since code built for a lower capability still runs on a higher card through the driver's just-in-time recompilation, but not the reverse.

The hardcoded default becomes sm_90, which is what the comment above it always claimed, and its examples now use the undotted form the flag actually takes. Passing COMPUTE_CAPABILITY on the make line still overrides everything, and still reaches the library from src.