### PR TITLE
Keep build output out of git, and let make clean remove all of it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,15 @@
 *.orig
 *.rej
 *~
+
+# Build output.  These were tracked once; keep them from coming back by way of
+# an absent-minded "git add ."  Compiled objects, Fortran module files, the
+# gravity library, and the executables, which are named after the directory
+# holding src and are also copied one level up.
+*.o
+*.cu_o
+*.mod
+*.a
+*__*.f90
+*_gpu_sph
+*_cpu_sph

--- a/parallel_bleeding_edge/src/Makefile
+++ b/parallel_bleeding_edge/src/Makefile
@@ -157,7 +157,7 @@ config:
 	@echo "  CPU executable  ../$(CPUEXEC)"
 
 clean:
-	/bin/rm -rf *.o *__*.f90 *.mod
+	/bin/rm -rf *.o *__*.f90 *.mod $(GPUEXEC) $(CPUEXEC) ../$(GPUEXEC) ../$(CPUEXEC)
 	$(MAKE) clean -C $(GRAVLIB)
 
 .PHONY: gpu cpu clean config check-cuda


### PR DESCRIPTION
A full build drops about forty object files, the Fortran module files, the gravity library and two executables into the working tree, and nothing ignored them.  They were tracked once and deliberately removed; a single absent-minded "git add ." would have put them all back.

make clean did not remove the executables either.  They are named after the directory holding src rather than by a fixed name, and one copy is left beside the objects while another is copied a level up, so neither was matched by the patterns in the clean target.

After this, a build followed by git status shows nothing, and make clean leaves the tree as it was found.