### PR TITLE
Take input file names from sph.input, and fix the missing-second-body…

### DIFF
--- a/parallel_bleeding_edge/src/init.f
+++ b/parallel_bleeding_edge/src/init.f
@@ -554,6 +554,8 @@ c      end
      $     omega_spin,neos,nselfgravity,gam,reat,starmass,starradius,
      $     ncooling,teq,tjumpahead,startfile1,startfile2,eosfile,
      $     opacityfile,profilefile,nkernel,throwaway,
+     $     startfile3,binaryfile,triplefile,bpbhfile,
+     $     imagefile,advectedfile,
      $     stellarevolutioncodetype,
      $     bbh_m1,bbh_m2,bbh_rp,bbh_semimajoraxis,bbh_vinf2,
      $     bbh_e0,bbh_trueanomaly,bbh_argperi,bbh_inclination,
@@ -569,22 +571,22 @@ c      end
       displacey=0d0
       displacez=0d0
 
-      semimajoraxis=0.d0
-      impactparameter=-1.d30
-      rp=-1.d30
-      e0=-1.d30
-      vinf2=1.d30
+      semimajoraxis=0.d0 ! orbital semimajor axis.  0 means unset, so that it is deduced from the others
+      impactparameter=-1.d30 ! impact parameter at infinity, an alternative to rp, converted to it using angular momentum
+      rp=-1.d30 ! separation at closest approach.  Set any two of rp, vinf2, e0 and semimajoraxis and the rest follow
+      e0=-1.d30 ! orbital eccentricity: 1 is parabolic, above 1 hyperbolic, below 1 bound
+      vinf2=1.d30 ! square of the relative speed at infinity.  1d30 means unset, so it is deduced from the others
 
-      bbh_m1=20d0
-      bbh_m2=10d0
-      bbh_semimajoraxis=0.d0
-      bbh_rp=-1.d30
-      bbh_e0=-1.d30
-      bbh_vinf2=1.d30
-      bbh_trueanomaly=0d0
-      bbh_argperi=0d0
-      bbh_inclination=0d0
-      bbh_longitude=0d0
+      bbh_m1=-1d0 ! first mass of a compact-object binary.  Required, and only used, when bbh_m2 is positive
+      bbh_m2=-1d0 ! second mass of a compact-object binary.  Negative means unset, giving a single point mass of mass mbh
+      bbh_semimajoraxis=0.d0 ! semimajor axis of the compact-object binary.  0 means unset
+      bbh_rp=-1.d30 ! separation at closest approach for the compact-object binary
+      bbh_e0=-1.d30 ! eccentricity of the compact-object binary
+      bbh_vinf2=1.d30 ! square of the relative speed at infinity for the compact-object binary.  1d30 means unset
+      bbh_trueanomaly=0d0 ! true anomaly of the compact-object binary, in degrees
+      bbh_argperi=0d0 ! argument of periapsis of the compact-object binary, in degrees
+      bbh_inclination=0d0 ! inclination of the compact-object binary, in degrees
+      bbh_longitude=0d0 ! longitude of the ascending node of the compact-object binary, in degrees
 
 c     set some default values, so that they don't necessarily have to be set in the sph.input file:
       tf=50000                 ! desired final time to stop simulation
@@ -600,10 +602,10 @@ c     set some default values, so that they don't necessarily have to be set in 
       mco=-1d30                ! mass of compact object or core particle
       hfloor=0d0               ! hp(i) = hptilde(i) + hfloor, where hp(i)=smoothing length and hptilde(i) is used in eq.(A1) of GLPZ 2010.
       nrelax=1                 ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation rotating frame with centrifugal and coriolis forces
-      trelax=1.d30             ! timescale for artificial drag force.  keep it very large to turn off the drag force, which seems best even in relaxation runs (as the av can do the relaxation).
+      trelax=1.d30             ! drag timescale.  0 derives both it and treloff from the model, a very large value disables the drag
       sep0=200                 ! initial separation of two stars in a binary or collision calculation
       equalmass=0              ! particle mass is proportional to rho^(1-equalmass), so equalmass=1 has equal mass particles and equalmass=0 is for constant number density.
-      treloff=0                ! time to end a relaxation and switch to a dynamical calculation
+      treloff=0                ! time the drag switches off and the run turns dynamical.  Overwritten when trelax=0
       tresplintmuoff=0.        ! time to stop resplinting the mean molecular weight.  leave this at 0.
       nitpot=1                 ! number of iterations between evaluation of the gravitational potential energy.
       tscanon=0                ! time that the scan of a binary starts
@@ -611,7 +613,7 @@ c     set some default values, so that they don't necessarily have to be set in 
       nintvar=2                ! 1=integrate entropic variable a, 2=integrate internal energy u
       ngravprocs=0             ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
       qthreads=0               ! number of gpu threads per particle. typically set to 1, 2, 4, or 8.  set to a negative value to optimize the number of threads by timing.  set to 0 to guess the best number of threads without timing.
-      mbh=10d0                 ! mass of black hole
+      mbh=10d0                 ! mass of the point mass used as the second object when startfile2 is absent
       runit=6.957d10          ! number of cm in the unit of length.  use 6.957d10 if want MESA solar radius.
       munit=1.9884098706980504d33          ! number of g in unit of mass.  use 1.9884098706980504E+033 if want MESA solar mass.
 !     the courant numbers cn1, cn2, cn3, and cn4 are for sph particles:
@@ -628,24 +630,30 @@ c     set some default values, so that they don't necessarily have to be set in 
 !     the final timestep dt is the minimum of dt_sph and dt_co for all particles i
       computeexclusivemode=0   ! set this to 1 if on machine like grapefree with gpus in compute exclusive mode; set this to 0 on supercomputers like lincoln
       omega_spin=0.d0 ! angular rotation rate of star, used in nrelax=1 relaxations to give a rigidly rotating model
-      ppn=16
+      ppn=16 ! cpu cores per node, used to spread the gravity processes over nodes
       neos=1 ! 0 for polytropic equation of state (eos), 1 for ideal gas + radiation pressure, 2 for tabulated eos
       nselfgravity=1 ! 0 if just do gravity to point particles, 1 if self-gravitating
       gam=5.d0/3.d0 ! leave this set at a reasonable value even if using neos=1 or 2 (because the value of gam is used in estimating the local sound speed in balav3.f)
-      reat=-1.d0
-      starmass=1d0
-      starradius=1d0
+      reat=-1.d0 ! radius within which a point mass swallows SPH particles.  Negative disables eating
+      starmass=1d0 ! mass of the polytrope to build, in solar masses
+      starradius=1d0 ! radius of the polytrope to build, in solar radii
       ncooling=0 ! 0 if no cooling, otherwise radiative cooling
-      nkernel=2
-      teq=100d0
-      tjumpahead=1d30
-      startfile1='sph.start1u'
-      startfile2='sph.start2u'
-      eosfile='sph.eos'
-      opacityfile='sph.opacity'
-      profilefile='eg.last1.muse_s2mm'
-      throwaway=.false.
-      stellarevolutioncodetype=1
+      nkernel=2 ! smoothing kernel: 0=cubic spline, 1=Wendland 3,3, 2=Wendland C4
+      teq=100d0 ! background temperature the cooling relaxes towards, in K.  Only used when ncooling>0
+      tjumpahead=1d30 ! time after which a wide orbit may be skipped rather than integrated.  Only acts when tf is negative
+      startfile1='sph.start1u' ! first body of the encounter, in out*.sph format, usually the last snapshot of a relaxation
+      startfile2='sph.start2u' ! second body, same format as startfile1.  If absent, a single point mass of mass mbh is used
+      startfile3='sph.start3u' ! third body of a triple, same format as startfile1
+      binaryfile='input.bs'    ! text file describing the binary, read by bps and 2cr
+      triplefile='input.3s'    ! text file describing the third body, read by bhe and tri
+      bpbhfile='sph.bpbh'      ! text file giving the orientation angles and black hole mass, read by bph
+      imagefile='sph.image'    ! ASCII picture that txt turns into a particle layout
+      advectedfile='sph.passivelyAdvected' ! per-particle passively advected quantities, read by hyp when present
+      eosfile='sph.eos' ! tabulated equation of state, read when neos selects a table
+      opacityfile='sph.opacity' ! tabulated opacities, read when cooling needs them
+      profilefile='eg.last1.muse_s2mm' ! stellar-evolution profile that erg builds its star from
+      throwaway=.false. ! when skipping ahead, discard unbound ejecta rather than keeping all mass as two components
+      stellarevolutioncodetype=1 ! which code wrote profilefile, since the column layouts differ
 
       open(12,file='sph.input',err=100,STATUS='OLD')
       read(12,input)

--- a/parallel_bleeding_edge/src/initialize_asciiimage.f
+++ b/parallel_bleeding_edge/src/initialize_asciiimage.f
@@ -7,7 +7,7 @@ c      parameter(imax=900,jmax=229)
       real*8 density(imax,jmaxmax)
 
       ip=0
-      open(12,file='sph.image')
+      open(12,file=imagefile)
       do j=1,jmaxmax
          read(12,'(900a1)',end=20)(line(i), i=1,imax)
          do i=1,imax

--- a/parallel_bleeding_edge/src/initialize_bpbh.f
+++ b/parallel_bleeding_edge/src/initialize_bpbh.f
@@ -38,7 +38,7 @@ c     used in subroutine dump)
       write(69,*)'n1=',n1
       amass1=n1
 
-      open(30,file='sph.bpbh')
+      open(30,file=bpbhfile)
       read(30,*) ph1,th1,ps1
       read(30,*) bhmass
       close(30)

--- a/parallel_bleeding_edge/src/initialize_bps.f
+++ b/parallel_bleeding_edge/src/initialize_bps.f
@@ -71,7 +71,7 @@ c break.  and that doesn't seem to be happening fortunately!
       write(69,*)'bps: reading in input.bs'
       corepts=0
 
-      open(30,file='input.bs')
+      open(30,file=binaryfile)
       read(30,*) dummy
       if(dummy.ne.'binary:')then
          write(69,*) 'input.bs should have binary first'

--- a/parallel_bleeding_edge/src/initialize_corotating.f
+++ b/parallel_bleeding_edge/src/initialize_corotating.f
@@ -24,10 +24,10 @@ c     calls gravquant,lfstart
       real*8 deltaxbin,deltaybin,deltazbin
       character*7 dummy
 
-      inquire(file='input.bs',exist=resetsep0)
+      inquire(file=binaryfile,exist=resetsep0)
       if(resetsep0)then
          write(69,*) 'will read file input.bs'
-         open(30,file='input.bs')
+         open(30,file=binaryfile)
          read(30,*) dummy
          if(dummy.ne.'binary:')then
             write(69,*) 'input.bs should have binary first'

--- a/parallel_bleeding_edge/src/initialize_hyperbolic.f
+++ b/parallel_bleeding_edge/src/initialize_hyperbolic.f
@@ -273,7 +273,7 @@ c     place velocities at same time as everything else:
 
          if(passivelyAdvected) then
             if(myrank.eq.0) write(69,*)'Reading in aa and bb values...',ntot
-            open(99,file='sph.passivelyAdvected',status='old')
+            open(99,file=advectedfile,status='old')
             do i=1,ntot
                read(99,*) aa(i),bb(i),dd(i)
             enddo
@@ -285,7 +285,7 @@ c     There is only one start file, so the second object will be a single or
 c     binary compact object
          if(passivelyAdvected) then
             if(myrank.eq.0) write(69,*)'Reading in aa and bb values...',n1
-            open(99,file='sph.passivelyAdvected',status='old')
+            open(99,file=advectedfile,status='old')
             do i=1,n1
                read(99,*) aa(i),bb(i),dd(i)
             enddo
@@ -305,8 +305,10 @@ c     binary compact object
      $        'startfile2 ',
      $        trim(startfile2),
      $        ' does not exist: will use'
-         if(.false.) then
-c     Second object will be a single compact object
+         if(bbh_m2.le.0.d0) then
+c     Second object will be a single compact object of mass mbh.  A binary is
+c     asked for by giving bbh_m2 a positive mass in sph.input.  The default is
+c     negative, so reaching the binary branch means the user set it deliberately.
             if(myrank.eq.0) write (69,*)
      $           'compact object particle instead'
             
@@ -344,7 +346,21 @@ c     Second object will be a single compact object
             if(myrank.eq.0) write(69,*)'compact_object_smoothing_length',
      $           hp(i)
          else
-c     Second object will be a compact object binary such as a binary black hole
+c     Second object will be a compact object binary such as a binary black hole.
+c     bbh_m2 being positive is what selected this branch, so bbh_m1 must have
+c     been set too.  Stopping here is better than proceeding with a primary mass
+c     the user never chose.
+            if(bbh_m1.le.0.d0) then
+               if(myrank.eq.0) then
+                  write(69,*)'hyperbolic: bbh_m2 is set, so the second'
+                  write(69,*)'hyperbolic: object is a compact-object binary,'
+                  write(69,*)'hyperbolic: but bbh_m1 has not been given a'
+                  write(69,*)'hyperbolic: positive mass.  Set bbh_m1 in'
+                  write(69,*)'hyperbolic: sph.input, or leave bbh_m2 unset'
+                  write(69,*)'hyperbolic: for a single point mass of mass mbh.'
+               endif
+               stop
+            endif
             if(myrank.eq.0) write (69,*)
      $           'binary compact object instead'
             n2=2

--- a/parallel_bleeding_edge/src/initialize_hyperbolic_binary_single.f
+++ b/parallel_bleeding_edge/src/initialize_hyperbolic_binary_single.f
@@ -1,6 +1,7 @@
       subroutine hyperbolic_binary_single
 c     hyperbolic collision with a neutron star
       include 'starsmasher.h'
+      logical startfileexists
       real*8 k,rdot,rdotcheck,costheta,sintheta,ltot,thetadot,
      $     semilatusrectum,mu,e0check,sinthetacheck,
      $     eorb0check,eorb0
@@ -36,8 +37,18 @@ c         write(69,*)'hns: rp=',rp
          write(69,*) 'hbs: impactparameter=',impactparameter,'v_inf2=',vinf2
       endif
          corepts=0
-         write (69,*) 'hbs: reading start files ...'
-         open(12,file='sph.startu',form='unformatted')
+         write (69,*) 'hbs: reading start file ',trim(startfile1)
+         inquire(file=startfile1,exist=startfileexists)
+         if(.not.startfileexists) then
+            if(myrank.eq.0) then
+               write(69,*)'hbs: cannot find start file ',trim(startfile1)
+               write(69,*)'hbs: set startfile1 in sph.input to the relaxed'
+               write(69,*)'hbs: star to use.  Earlier versions of this'
+               write(69,*)'hbs: routine always read sph.startu.'
+            endif
+            stop
+         endif
+         open(12,file=startfile1,form='unformatted')
 c     (the following read sequence must match exactly the write sequence
 c     used in subroutine dump)
          read(12) n1,nnoptold,hcoold,hfloorold,sep0old,

--- a/parallel_bleeding_edge/src/initialize_smbh.f
+++ b/parallel_bleeding_edge/src/initialize_smbh.f
@@ -95,7 +95,7 @@ c            stop
       close(12)
       if (nchk.ne.n2) stop 'smbh: problem with file'
 
-      open(30,file='input.3s')
+      open(30,file=triplefile)
       read(30,*) dummy
       read(30,*) am3chk
       read(30,*) deltax3,deltay3,deltaz3

--- a/parallel_bleeding_edge/src/initialize_triple.f
+++ b/parallel_bleeding_edge/src/initialize_triple.f
@@ -88,7 +88,7 @@ c     place velocities at same time as everything else:
       close(12)
       if (nchk.ne.n2) stop 'triple: problem with file'
 
-      open(12,file='sph.start3u',form='unformatted')
+      open(12,file=startfile3,form='unformatted')
 c     (the following read sequence must match exactly the write sequence
 c     used in subroutine dump)
       read(12) n3,nnoptold,hcoold,hfloorold,sep0old,
@@ -123,7 +123,7 @@ c     place velocities at same time as everything else:
       n=ntot-corepts
       write (69,*)'triple: n=',n,'ntot=',ntot
 
-      open(30,file='input.3s')
+      open(30,file=triplefile)
       read(30,*) dummy
       read(30,*) am1chk
       read(30,*) deltax1,deltay1,deltaz1

--- a/parallel_bleeding_edge/src/starsmasher.h
+++ b/parallel_bleeding_edge/src/starsmasher.h
@@ -62,9 +62,12 @@
       integer neos,nusegpus,nselfgravity,ncooling,nkernel
       real*8 gam,teq,tjumpahead
       character*255 startfile1,startfile2,eosfile,opacityfile,profilefile
+      character*255 startfile3,binaryfile,triplefile,bpbhfile
+      character*255 imagefile,advectedfile
       logical throwaway
       integer stellarevolutioncodetype	
       common/inputfilenames/startfile1,startfile2,eosfile,opacityfile,profilefile
+      common/inputfilenames2/startfile3,binaryfile,triplefile,bpbhfile,imagefile,advectedfile
       common/courantnumbers/ cn1,cn2,cn3,cn4,cn5,cn6,cn7
       common/integration/nintvar,neos,nusegpus,nselfgravity,ncooling,nkernel
       parameter(kdm=5000)


### PR DESCRIPTION
… case

Three related changes to how the initialization scripts are configured.

Input file names are no longer compiled in.  Several scripts opened fixed names, so a directory could hold only one calculation and the name a body was given bore no relation to what it was.  Each name now comes from the namelist, defaulting to the name that was previously hardcoded, so existing directories keep working untouched:

  startfile3   sph.start3u             third body of a triple
  binaryfile   input.bs                bps and 2cr
  triplefile   input.3s                bhe and tri
  bpbhfile     sph.bpbh                bph
  imagefile    sph.image               txt
  advectedfile sph.passivelyAdvected   hyp

hbs read sph.startu regardless of startfile1, so that setting silently did nothing for it.  It now uses startfile1 like the others and says what to set when the file is missing rather than failing on the open.  In initialize_corotating.f an inquire and an open referred to the same file by two separate literals, and both now use binaryfile so they cannot drift apart.

When startfile2 is absent the second object is a single point mass again.  The branch that does this was present but disabled behind if(.false.), so every such run silently got a compact-object binary built from bbh_m1 and bbh_m2 instead. The binary is now selected by giving bbh_m2 a positive mass, and both bbh_m1 and bbh_m2 default to a negative value, so reaching that branch means the user asked for it.  Setting bbh_m2 without bbh_m1 stops the run rather than proceeding with a primary mass nobody chose.

The remaining settings in the namelist now carry a description on their initialization line, which is where the reference documentation reads them from. The comment on trelax still advised keeping the drag off, which contradicts the schedule derivation added when trelax=0 was introduced.

Tested by relaxing a polytrope and handing the snapshot to tri three times under names that are not the defaults, which fails if any script falls back to a compiled-in name, and again with the defaults in place, which must still find the old names.  The compact-object gate was checked across its boundary with bbh_m2 negative, zero and positive, and with bbh_m2 set while bbh_m1 was not. The existing suite passes unchanged.