### PR TITLE
Relax the example stars with a drag schedule instead of none

### DIFF
--- a/example_input/Creating_a_MESA_star/sph.input
+++ b/example_input/Creating_a_MESA_star/sph.input
@@ -9,16 +9,14 @@
  beta=2, ! av coefficient for mu^2 term
  ngr=3, ! gravity flag.  leave it at 3.  if your want no gravity, ngr=0 might still work.
  nrelax=1, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation in corotating frame with centrifugal and coriolis forces
- trelax=1d30, ! timescale for artificial drag force.  keep it very large to turn off the drag force, which seems best even in relaxation runs (as the av can do the relaxation).
+ trelax=0, ! 0 asks for the drag schedule to be derived from the model, which also sets treloff
  sep0=20000, ! initial separation of two stars in a binary or collision calculation
  equalmass=0, ! 0=uniform number density, 1=equal mass particles; in general m_i ~ rho_i^(1-equalmass)
- treloff=1, ! time to end a relaxation and switch to a dynamical calculation
  tresplintmuoff=0., ! time to stop resplinting the mean molecular weight.  leave this at 0.
  nitpot=1, ! number of iterations between evaluation of the gravitational potential energy.
  tscanon=0, ! time that the scan of a binary starts
  sepfinal=1.d30, ! final separation for the scan of a binary
  nintvar=2, ! 1=integrate entropic variable a, 2=integrate internal energy u
- ngravprocs=-1, ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
  qthreads=0 ! number of gpu threads per particle. typically set to 1, 2, 4, or 8.  set to a negative value to optimize the number of threads by timing.  set to 0 to guess the best number of threads without timing.
  gflag=1 ! set to 0 for g function from appendix of gaburov et al. (2010); set to 1 for a g function that works better when there are black holes
 ! the courant numbers cn1, cn2, cn3, and cn4 are for sph particles:

--- a/example_input/relaxation_TWIN_model/sph.input
+++ b/example_input/relaxation_TWIN_model/sph.input
@@ -8,11 +8,9 @@
  beta=2, ! av coefficient for mu^2 term
  ngr=3, ! gravity flag.  leave it at 3.  if your want no gravity, ngr=0 might still work.
  nrelax=1, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation in corotating frame with centrifugal and coriolis forces
- trelax=1d30, ! timescale for artificial drag force.  keep it very large to turn off the drag force, which seems best even in relaxation runs (as the av can do the relaxation).
+ trelax=0, ! 0 asks for the drag schedule to be derived from the model, which also sets treloff
  equalmass=0, ! 0=uniform number density, 1=equal mass particles; in general m_i ~ rho_i^(1-equalmass)
- treloff=0, ! time to end a relaxation and switch to a dynamical calculation
  nintvar=2, ! 1=integrate entropic variable a, 2=integrate internal energy u
- ngravprocs=-1, ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
  gflag=1 ! set to 0 for g function from appendix of gaburov et al. (2010); set to 1 for a g function that works better when there are black holes
 ! the courant numbers cn1, cn2, cn3, and cn4 are for sph particles:
 ! dt_sph=1/(1/dt1 + 1/dt2 + 1/dt3 + 1/dt4)

--- a/example_input/relaxation_preMS/sph.input
+++ b/example_input/relaxation_preMS/sph.input
@@ -5,8 +5,7 @@
  starmass=0.2, ! The desired mass of your preMS star!
  starradius=0.2, ! The desired radius of your preMS star!
  nrelax=1, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation in corotating frame with centrifugal and coriolis forces
- treloff=0, ! time to end a relaxation and switch to a dynamical calculation
- ngravprocs=-2, ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
+ trelax=0, ! 0 asks for the drag schedule to be derived from the model, which also sets treloff
  computeexclusivemode=0, ! set this to 1 if on machine like grapefree with gpus in compute exclusive mode; set this to 0 on supercomputers like forge
  ppn=16, ! set this to the number of cpu cores per node
  &end

--- a/example_input/relaxation_rotating_giant/sph.input
+++ b/example_input/relaxation_rotating_giant/sph.input
@@ -8,16 +8,14 @@
  beta=2, ! av coefficient for mu^2 term
  ngr=3, ! gravity flag.  leave it at 3.  if your want no gravity, ngr=0 might still work.
  nrelax=1, ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation rotating frame with centrifugal and coriolis forces
- trelax=200, ! timescale for artificial drag force.  keep it very large to turn off the drag force, which seems best even in relaxation runs (as the av can do the relaxation).
+ trelax=0, ! 0 asks for the drag schedule to be derived from the model, which also sets treloff
  sep0=200, ! initial separation of two stars in a binary or collision calculation
  equalmass=0, ! 0=uniform number density, 1=equal mass particles; in general m_i ~ rho_i^(1-equalmass)
- treloff=10000, ! time to end a relaxation and switch to a dynamical calculation
  tresplintmuoff=0., ! time to stop resplinting the mean molecular weight.  leave this at 0.
  nitpot=1, ! number of iterations between evaluation of the gravitational potential energy.
  tscanon=0, ! time that the scan of a binary starts
  sepfinal=1.d30, ! final separation for the scan of a binary
  nintvar=2, ! 1=integrate entropic variable a, 2=integrate internal energy u
- ngravprocs=-2 ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
  qthreads=0 ! number of gpu threads per particle. typically set to 1, 2, 4, or 8.  set to a negative value to optimize the number of threads by timing.  set to 0 to guess the best number of threads without timing.
  gflag=1 ! set to 0 for g function from appendix of gaburov et al. (2010); set to 1 for a g function that works better when there are black holes
 ! the courant numbers cn1, cn2, cn3, and cn4 are for sph particles:


### PR DESCRIPTION
Three of the four single-star relaxation examples set trelax=1d30, which turns the artificial drag off entirely, and the fourth left it unset and so got the same thing by default.  That was the advice the comment on trelax used to give. It is no longer, and these files are what people copy: the quickstart tells a new user to start from relaxation_preMS, so whatever habit they encode is the habit that gets learned.

All four now use trelax=0, which derives the drag timescale and the release time from the model.  treloff is removed along with it, because trelax=0 overwrites whatever it is given, and a setting that is silently discarded is worse than an absent one.

relaxation_rotating_giant had trelax=200 and treloff=10000 chosen by hand for that particular star, which is exactly the work the derivation now does.

ngravprocs is dropped from all four.  It was pinned to -1 or -2, which describes the machine the file was last run on rather than the machine reading it, and 0 detects what is actually present.

corotating_binary is left alone deliberately.  It relaxes a binary in a corotating frame, and the derivation takes the radius over every particle, so for two stars it would measure the separation rather than a stellar radius and produce a timescale that means nothing.  The dynamical examples keep trelax=1d30, where no drag is the intended behaviour.

Checked by relaxing the preMS example at n=4000: the schedule derives itself to trelax=0.626 and treloff=6.26 from a dynamical time of 0.157, and the star settles to a kinetic energy of 9e-12.