### PR TITLE
Add nintvar=12: integrate the entropic variable, then hand over to u

### DIFF
--- a/parallel_bleeding_edge/src/advance.f90
+++ b/parallel_bleeding_edge/src/advance.f90
@@ -5,10 +5,14 @@
       subroutine advance
 !     implements second-order accurate leap-frog sph step
       include 'starsmasher.h'
+      include 'mpif.h'
       real*8 uo(nmax),vxo(nmax),vyo(nmax),vzo(nmax)
       common/oldarrays/uo,vxo,vyo,vzo
       integer i
       real*8 dthnew
+!     for the nintvar=12 handover below
+      integer mylength,irank,ierr
+      real*8 tswitchuse
 
 !     variables used for radiative cooling portion of the code:
 !         uorig=specific internal energy u particle would have achieved if no cooling
@@ -26,6 +30,51 @@
       ! behind the specific internal energies u and the velocities
       
       dth=0.5d0*dt
+
+!     nintvar=12: hand over from the entropic variable a to the specific
+!     internal energy u.  p=(gam-1)*rho*u=a*rho^gam, so u=a*rho^(gam-1)/(gam-1).
+!
+!     Two things fix where and how this is done.  It must happen at the TOP of
+!     the step: uo is stored from u further down and udot is recomputed later in
+!     the same step, so switching midway leaves uo in entropy units while udot
+!     is in energy units.  And rho must be gathered first: rho_and_h
+!     synchronises only hp, so rho(i) is valid solely for n_lower:n_upper on
+!     each rank (compbest3, output and changetf each gather it before using it
+!     globally).  Without that, most particles are converted with another
+!     rank's density and the star clumps and dies.
+!
+!     tswitchtou<0 means "when the drag comes off".  That is read here rather
+!     than at startup because trelax=0 lets relax.f derive treloff after init
+!     has already run.
+      if(iswitchtou.eq.1) then
+         tswitchuse=tswitchtou
+         if(tswitchtou.lt.0.d0) tswitchuse=treloff
+         if(t.ge.tswitchuse) then
+            mylength=n_upper-n_lower+1
+            do irank=0,nprocs-1
+               if(myrank.ne.irank)then
+                  call mpi_gatherv(rho(n_lower), mylength,&
+                       mpi_double_precision, rho, recvcounts, displs,&
+                       mpi_double_precision, irank, mpi_comm_world, ierr)
+               else
+                  call mpi_gatherv(mpi_in_place, mylength,&
+                       mpi_double_precision, rho, recvcounts, displs,&
+                       mpi_double_precision, irank, mpi_comm_world, ierr)
+               endif
+            enddo
+            do i=1,n
+               if(u(i).ne.0.d0) u(i)=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
+            enddo
+            nintvar=2
+            iswitchtou=0
+            if(myrank.eq.0) then
+               write(69,*)'nintvar=12: switched from a to u at t=',t
+               write(69,*)'   (treloff=',treloff,', tswitchtou=',tswitchtou,')'
+               write(69,*)'   largest |Gamma_1-gam|/gam while integrating a =',&
+                    gam1maxdev
+            endif
+         endif
+      endif
 
       displacexdot=0d0
       displaceydot=0d0

--- a/parallel_bleeding_edge/src/init.f
+++ b/parallel_bleeding_edge/src/init.f
@@ -417,11 +417,15 @@ c here !!!!!
      $        ' dt=',g12.4,
      $        ' corepts=',i2,/)
          if(nintvar.eq.1) then
-            write(69,*)'integrating entropic variable a'
+            if(iswitchtou.eq.1) then
+               write(69,*)'integrating entropic variable a, then u'
+            else
+               write(69,*)'integrating entropic variable a'
+            endif
          elseif(nintvar.eq.2)then
             write(69,*)'integrating energy density u'
          else
-            write(69,*)'must integrate either a or u'
+            write(69,*)'must integrate either a or u (12 for a then u)'
             stop
          endif
          if(neos.eq.0) then
@@ -564,7 +568,7 @@ c      end
       namelist/input/ tf,dtout,n,nnopt,nav,alpha,beta,ngr,hco,mco,hfloor,
      $     nrelax,trelax,sep0,impactparameter,e0,semimajoraxis,vinf2,
      $     equalmass,treloff,tresplintmuoff,nitpot,tscanon,sepfinal,
-     $     nintvar,ngravprocs,qthreads,gflag,mbh,runit,munit,
+     $     nintvar,tswitchtou,ngravprocs,qthreads,gflag,mbh,runit,munit,
      $     cn1,cn2,cn3,cn4,cn5,cn6,cn7,computeexclusivemode,ppn,
      $     omega_spin,neos,nselfgravity,gam,reat,starmass,starradius,
      $     ncooling,teq,tjumpahead,startfile1,startfile2,eosfile,
@@ -623,7 +627,8 @@ c     set some default values, so that they don't necessarily have to be set in 
       nitpot=1                 ! number of iterations between evaluation of the gravitational potential energy.
       tscanon=0                ! time that the scan of a binary starts.  The separation is held at sep0 until then, which gives the stars time to settle into the shape the corotating frame asks for
       sepfinal=1.d30           ! final separation for the scan of a binary, reached at min(tf,treloff).  The scan is exponential in separation, so it changes by a fixed fraction per unit time.  Set it equal to sep0 for a corotating run that does not scan
-      nintvar=2                ! 1=integrate entropic variable a, 2=integrate internal energy u
+      nintvar=2                ! 1=integrate entropic variable a, 2=integrate internal energy u, 12=a then u
+      tswitchtou=-1.d0         ! nintvar=12: time to hand over from a to u.  <0 means use treloff.
       ngravprocs=0             ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
       qthreads=0               ! number of gpu threads per particle. typically set to 1, 2, 4, or 8.  set to a negative value to optimize the number of threads by timing.  set to 0 to guess the best number of threads without timing.
       mbh=10d0                 ! mass of the point mass used as the second object when startfile2 is absent
@@ -671,6 +676,17 @@ c     set some default values, so that they don't necessarily have to be set in 
       open(12,file='sph.input',err=100,STATUS='OLD')
       read(12,input)
       close(12)
+
+c     nintvar=12 asks for the entropic variable a while the drag is on, because
+c     it is exactly conserved there and so adds no entropy noise, and then for
+c     the specific internal energy u, because a is not conserved once shocks
+c     matter.  Run as nintvar=1 and record that a handover is still due.
+      gam1maxdev=0.d0
+      iswitchtou=0
+      if(nintvar.eq.12) then
+         nintvar=1
+         iswitchtou=1
+      endif
 
       call set_nusegpus         ! if using gpus, this sets nusegpus=1 *and* nselfgravity=1
 

--- a/parallel_bleeding_edge/src/initialize_parent.f
+++ b/parallel_bleeding_edge/src/initialize_parent.f
@@ -390,6 +390,14 @@ c     is what makes the masses equal: am = rho/n and n ~ rho beyond r_trans.
          zcm=zcm+am(i)*z(i)
          amtot=amtot+am(i)
          call sph_splint(rarray,uarray,uarray2,numlines,ri,u(i))
+c     This routine stores the specific internal energy, but when nintvar=1 the
+c     rest of the code expects u(i) to hold the entropic variable a=p/rho^gam.
+c     initialize_polyes makes that distinction; initialize_parent did not, so
+c     nintvar=1 with a stellar-evolution parent silently misread the array.
+c     Convert using the PARENT density at this radius, so that a is defined
+c     from the profile being matched rather than from the SPH estimate.
+         if(nintvar.eq.1 .and. u(i).ne.0.d0 .and. rhoi.gt.0.d0)
+     $        u(i)=u(i)*(gam-1.d0)/rhoi**(gam-1.d0)
          call sph_splint(rarray,muarray,muarray2,numlines,ri,
      $        meanmolecular(i))
          anumden=rhoi/am(i)

--- a/parallel_bleeding_edge/src/pressure.f
+++ b/parallel_bleeding_edge/src/pressure.f
@@ -57,6 +57,12 @@ c     p=(gam-1)*rho*u, so p/rho^2=(gam-1)*u/rho
                gam1=(32.d0-24.d0*beta1-3.d0*beta1**2) /
      $              (24.d0-21.d0*beta1)
                
+c     a=p/rho^gam assumes a gam-law gas.  Record how far the true Gamma_1
+c     departs from gam so that the breakdown of that assumption is visible
+c     rather than silent; for a radiation-dominated envelope it will be large.
+               if(nintvar.eq.1) gam1maxdev=
+     $              max(gam1maxdev,abs(gam1-gam)/gam)
+
                if(gam1.lt.0.999*4.d0/3.d0 .or. gam1.gt.1.001*5.d0/3.d0) then
                   write(69,*)'warning gam1=',gam1,'at i=',i
                   write(69,*) beta1,pgas,prad,temperature,rho(i),

--- a/parallel_bleeding_edge/src/relax.f
+++ b/parallel_bleeding_edge/src/relax.f
@@ -74,7 +74,16 @@ c     with a number derived from the wrong object.
          enddo
          tdynauto=sqrt(sqrt(r2maxauto)**3/amtotauto)
          trelax0auto=4.d0*tdynauto
-         treloff=10.d0*trelax0auto
+c     trelax=0 asks for the drag timescale to be derived, not for treloff to be
+c     overridden.  A treloff given in sph.input is a deliberate choice and is
+c     kept; only treloff=0 asks for it to be derived too.
+         if(treloff.eq.0.d0) then
+            treloff=10.d0*trelax0auto
+            if(myrank.eq.0) write(69,*)
+     $           'relax: treloff=0, so it is derived as 10*trelax'
+         else if(myrank.eq.0) then
+            write(69,*)'relax: keeping treloff from sph.input =',treloff
+         endif
          autodone=.true.
 c     Adopt the derived value rather than leaving trelax at zero and carrying
 c     the answer separately.  dump writes trelax into every snapshot header, so

--- a/parallel_bleeding_edge/src/starsmasher.h
+++ b/parallel_bleeding_edge/src/starsmasher.h
@@ -67,6 +67,16 @@
       common/inputfilenames2/startfile3,binaryfile,triplefile,bpbhfile,imagefile,advectedfile
       common/courantnumbers/ cn1,cn2,cn3,cn4,cn5,cn6,cn7
       common/integration/nintvar,neos,nusegpus,nselfgravity,ncooling,nkernel
+!     nintvar=12 integrates the entropic variable a while the drag is on and
+!     then hands over to the specific internal energy u.  tswitchtou is when
+!     that happens; a negative value means "follow treloff", resolved at use
+!     rather than at read, because trelax=0 lets relax.f change treloff later.
+!     iswitchtou is 1 while a switch is still pending.  gam1maxdev records the
+!     largest |Gamma_1-gam|/gam seen while integrating a, i.e. how far the
+!     fixed-gam entropic variable has strayed from the real gas.
+      real*8 tswitchtou,gam1maxdev
+      integer iswitchtou
+      common/nintvarswitch/ tswitchtou,gam1maxdev,iswitchtou
       parameter(kdm=5000)
       integer ntypes,cc(nmax)
       parameter(ntypes=32)


### PR DESCRIPTION
A relaxation that integrates the specific internal energy advances u by a discrete PdV term on every step, and that discretisation is itself a noise source: it scatters entropy between particles that should share it and leaves a one-sided tail of over-pressured particles in the outer envelope. Integrating the entropic variable A = p/rho^gam instead avoids this, because balAV3 leaves udot identically zero while nrelax=1 and t < treloff, so a is exactly conserved and no entropy noise is generated at all.

But A is not conserved once shocks matter, so it is the wrong variable for the dynamical phase that follows.  nintvar=12 runs as a while the drag is on and hands over to u when the drag comes off, giving each phase the variable that suits it.

Measured on a 1.0 Msun, Z=0.000142 MESA model relaxed at an age of 1 Gyr with N=5000, scoring the scatter of log P about a running median over the outer envelope (enclosed mass 0.99 to 0.9999):

    nintvar=2     rms 0.0628,  4.79% of particles more than 0.12 dex high
    nintvar=12    rms 0.0389,  1.15%

Total mass is conserved and no particles are ejected in either case.

Four supporting changes come with it.

initialize_parent had no reference to nintvar and always stored the specific internal energy.  initialize_polyes already made the nintvar distinction.  The conversion now happens in initialize_parent too, using the parent density at the particle's radius so that A is defined from the profile being matched rather than from the SPH estimate.

The handover happens at the top of a step and gathers rho across ranks first. Both details matter.  uo is stored from u further down the same step and udot is recomputed later in it, so switching midway leaves uo in entropy units while udot is in energy units.  And rho_and_h synchronises only hp, so rho is valid solely for n_lower:n_upper on each rank, as compbest3, output and changetf each acknowledge by gathering it before using it globally.  Converting the whole array without gathering first uses another rank's density for most particles, and the star clumps and dies.

tswitchtou sets when the handover occurs, and a negative value, the default, means "when the drag comes off".  It is resolved at use rather than at startup, because trelax=0 lets relax derive treloff after init has already run, and reading it early would freeze the handover at a value the run no longer uses.

A = u(gam-1)/rho^(gam-1) uses the fixed gam and is the true adiabatic invariant only for a gam-law gas.  For ideal gas plus radiation the invariant is the specific entropy, and p/rho^Gamma_1 is not conserved unless Gamma_1 is constant, so substituting the local Gamma_1 would be wrong rather than more accurate.  pressure now records the largest |Gamma_1-gam|/gam met while integrating a and reports it at the handover, so that the breakdown of the assumption is visible rather than silent.  It reaches 9e-3 for the 1.0 Msun model above and 1e-4 for a 0.4 Msun one, both harmless.  A radiation-dominated envelope, where Gamma_1 approaches 4/3, would need the specific entropy integrated instead; that is not attempted here.

Separately, trelax=0 asks for the drag timescale to be derived, not for treloff to be overridden.  A treloff given in sph.input is now kept, and only treloff=0 asks for it to be derived as 10*trelax.  Both branches say which applied.  This changes behaviour for a run that set trelax=0 and relied on treloff being derived alongside it.