### PR TITLE
Document nintvar=12 and correct what trelax=0 actually does

### DIFF
--- a/docs/source/reference/sph_input.rst
+++ b/docs/source/reference/sph_input.rst
@@ -16,7 +16,7 @@ begins with ``&input`` and ends with ``&end``::
 
    The variables, defaults and descriptions on this page are read directly
    from the namelist declaration and the default-initialisation block in
-   ``parallel_bleeding_edge/src/init.f``.  There are **75** settings.
+   ``parallel_bleeding_edge/src/init.f``.  There are **76** settings.
 
 
 .. _sph-input-time-and-output:
@@ -185,11 +185,11 @@ Relaxation
    * - ``trelax``
      - ``1.d30``
      - every run
-     - drag timescale.  0 derives it from the model, and for a single star sets treloff with it, a very large value disables the drag
+     - drag timescale.  0 derives it from the model, a very large value disables the drag
    * - ``treloff``
      - ``0``
      - every run
-     - time the drag switches off and the run turns dynamical.  It ends a scan as well, since a scan runs until min(tf,treloff).  Overwritten when trelax=0 for a single star
+     - time the drag switches off and the run turns dynamical.  It ends a scan as well, since a scan runs until min(tf,treloff).  0 asks for it to be derived as 10\*trelax, which for a single star needs trelax=0 as well
    * - ``tresplintmuoff``
      - ``0.``
      - every run
@@ -311,7 +311,7 @@ Timestep control
    * - ``nintvar``
      - ``2``
      - every run
-     - 1=integrate entropic variable a, 2=integrate internal energy u
+     - 1=integrate entropic variable a, 2=integrate internal energy u, 12=a then u
    * - ``cn1``
      - ``.3d0``
      - every run
@@ -458,4 +458,22 @@ Input files
      - ``1``
      - ``erg``
      - which code wrote profilefile, since the column layouts differ
+
+.. _sph-input-other-settings:
+
+Other settings
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 19 16 20 45
+
+   * - Variable
+     - Default
+     - Applies to
+     - Meaning
+   * - ``tswitchtou``
+     - ``-1.d0``
+     - every run
+     - nintvar=12: time to hand over from a to u.  <0 means use treloff.
 

--- a/docs/source/tutorials/relaxing_a_star.rst
+++ b/docs/source/tutorials/relaxing_a_star.rst
@@ -54,14 +54,22 @@ drag is switched off.
 
 .. important::
 
-   ``trelax=0`` sets ``treloff`` as well, overwriting whatever you put there.
-   You cannot derive one and hand-set the other.  It is both or neither.
+   ``trelax=0`` derives the drag timescale only.  A ``treloff`` you set in
+   ``sph.input`` is kept, so you can derive one and hand-set the other.  Only
+   ``treloff=0`` asks for it to be derived as well, as ten times ``trelax``.
+   ``log0.sph`` says which of the two applied::
+
+       relax: keeping treloff from sph.input =   ...
+
+   or::
+
+       relax: treloff=0, so it is derived as 10*trelax
 
 When to override it
 ~~~~~~~~~~~~~~~~~~~
 
-Setting ``trelax`` to a positive value keeps its old meaning exactly, and then
-``treloff`` is yours to set too.  Two reasons to do so:
+Setting ``trelax`` to a positive value keeps its old meaning exactly.  Two
+reasons to do so:
 
 **A very soft envelope.**  Where :math:`\Gamma_1` approaches 4/3 the period
 lengthens sharply, and :math:`4\,t_\mathrm{dyn}` will underestimate it.  The
@@ -78,6 +86,67 @@ to ten times it.
    On a resumed run the schedule is derived again from the star as it now is,
    which has already relaxed and so is slightly smaller than the one it started
    from.  ``log0.sph`` says so when this happens.
+
+.. dropdown:: Integrating the entropic variable while the drag is on, for a smoother model
+   :icon: gear
+
+   ``nintvar`` chooses what the integrator advances.  The default, ``2``, is the
+   specific internal energy :math:`u`.  ``1`` is the entropic variable
+   :math:`a = p/\rho^\gamma`.  ``12`` uses ``1`` while the drag is on and hands
+   over to ``2`` when it comes off, which is usually what you want for a
+   relaxation whose product will later be collided.
+
+   While ``nrelax=1`` and :math:`t <` ``treloff``, ``balAV3`` leaves ``udot``
+   identically zero, so with ``nintvar=1`` each particle's entropy is exactly
+   conserved and the relaxation adds no entropy noise at all.  With ``nintvar=2``
+   the same phase advances :math:`u` by a discrete :math:`p\,dV` term on every
+   step, and that discretisation scatters entropy between particles that should
+   share it.  It shows up as a one-sided tail of over-pressured particles in the
+   outer envelope, where the density scale height is shortest and the smoothing
+   length is least able to resolve it.
+
+   On a 1.0 :math:`M_\odot`, :math:`Z=0.000142` MESA model relaxed at an age of
+   1 Gyr with ``n=5000``, scoring the scatter of :math:`\log P` about a running
+   median over the outer envelope (enclosed mass 0.99 to 0.9999):
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 30 50
+
+      * - ``nintvar``
+        - rms of :math:`\log P`
+        - particles more than 0.12 dex high
+      * - ``2``
+        - 0.0628
+        - 4.79 per cent
+      * - ``12``
+        - 0.0389
+        - 1.15 per cent
+
+   Mass is conserved and no particles are ejected either way.
+
+   The handover matters because :math:`a` is conserved only while the flow is
+   adiabatic.  Once the drag is off and shocks can form, :math:`u` is the
+   variable that carries the dissipated energy correctly, so ``12`` gives each
+   phase the variable that suits it.  ``tswitchtou`` sets when the handover
+   happens; its default, a negative value, means "when the drag comes off", and
+   is read at the moment of the test so that it follows a ``treloff`` that
+   ``trelax=0`` derived.
+
+   .. warning::
+
+      :math:`a = u(\gamma-1)/\rho^{\gamma-1}` uses the fixed ``gam``, and is
+      the true adiabatic invariant only for a :math:`\gamma`-law gas.  For ideal
+      gas plus radiation the invariant is the specific entropy, and
+      :math:`p/\rho^{\Gamma_1}` is not conserved unless :math:`\Gamma_1` is
+      constant, so substituting the local :math:`\Gamma_1` would be wrong rather
+      than more accurate.  The code records the largest
+      :math:`|\Gamma_1-\mathrm{gam}|/\mathrm{gam}` met while integrating
+      :math:`a` and reports it in ``log0.sph`` at the handover.  It reaches
+      :math:`9\times10^{-3}` for the model above and :math:`10^{-4}` for a 0.4
+      :math:`M_\odot` one, both harmless.  A radiation-dominated envelope, where
+      :math:`\Gamma_1` approaches 4/3, would need the specific entropy
+      integrated instead; that is not implemented.
 
 Judging whether the model is any good
 -------------------------------------

--- a/parallel_bleeding_edge/src/init.f
+++ b/parallel_bleeding_edge/src/init.f
@@ -619,10 +619,10 @@ c     set some default values, so that they don't necessarily have to be set in 
       mco=-1d30                ! mass of compact object or core particle
       hfloor=0d0               ! hp(i) = hptilde(i) + hfloor, where hp(i)=smoothing length and hptilde(i) is used in eq.(A1) of GLPZ 2010.
       nrelax=1                 ! relaxation flag.  0=dynamical calculation, 1=relaxation of single star, 2=relaxation of binary in corotating frame with centrifugal force, 3=calculation rotating frame with centrifugal and coriolis forces
-      trelax=1.d30             ! drag timescale.  0 derives it from the model, and for a single star sets treloff with it, a very large value disables the drag
+      trelax=1.d30             ! drag timescale.  0 derives it from the model, a very large value disables the drag
       sep0=200                 ! initial separation of two stars in a binary or collision calculation, and the separation a scan starts from and holds until tscanon
       equalmass=0              ! particle mass is proportional to rho^(1-equalmass), so equalmass=1 has equal mass particles and equalmass=0 is for constant number density.
-      treloff=0                ! time the drag switches off and the run turns dynamical.  It ends a scan as well, since a scan runs until min(tf,treloff).  Overwritten when trelax=0 for a single star
+      treloff=0                ! time the drag switches off and the run turns dynamical.  It ends a scan as well, since a scan runs until min(tf,treloff).  0 asks for it to be derived as 10*trelax, which for a single star needs trelax=0 as well
       tresplintmuoff=0.        ! time to stop resplinting the mean molecular weight.  leave this at 0.
       nitpot=1                 ! number of iterations between evaluation of the gravitational potential energy.
       tscanon=0                ! time that the scan of a binary starts.  The separation is held at sep0 until then, which gives the stars time to settle into the shape the corotating frame asks for

--- a/parallel_bleeding_edge/src/initialize_corotating.f
+++ b/parallel_bleeding_edge/src/initialize_corotating.f
@@ -159,10 +159,10 @@ c     that star's particles only, and runs here rather than later because the
 c     stars have not yet been moved out to sep0, so the radius it finds is the
 c     stellar one and does not depend on the separation.
 c
-c     treloff is deliberately left alone.  relax.f ties treloff to trelax when
-c     it derives a schedule, but for a corotating binary treloff also fixes
-c     tscanoff and so sets how long a scan lasts; deriving it here would let
-c     the star silently redefine the scan.
+c     treloff is deliberately left alone.  relax.f derives treloff alongside
+c     trelax only when treloff was left at zero, but for a corotating binary
+c     treloff also fixes tscanoff and so sets how long a scan lasts; deriving
+c     it here would let the star silently redefine the scan.
       if(trelax.eq.0.d0) then
          if(trelaxold.gt.0.d0 .and. trelaxold.lt.1.d29) then
             trelax=trelaxold


### PR DESCRIPTION
The tutorial told the reader that trelax=0 sets treloff as well and that you cannot derive one and hand-set the other.  That was true when it was written and is now the opposite of what relax.f does: a treloff given in sph.input is kept, and only treloff=0 asks for it to be derived as ten times trelax.  The important box now says so and quotes both of the log lines that report which branch applied, so a reader can check their own run rather than trust the prose.  The two stale source comments that said the same thing, in init.f and initialize_corotating.f, are corrected too.

nintvar=12 gets a dropdown, collapsed by default, placed before the section on judging the model.  It is a detail most readers relaxing a star for the first time do not need, but it changes the result enough to be worth finding.  It explains that balAV3 leaves udot identically zero while the drag is on, so integrating the entropic variable adds no entropy noise where integrating u pays a PdV discretisation error every step; it gives the measured comparison on a 1.0 Msun model at N=5000, where the rms of log P about a running median over the outer envelope falls from 0.063 to 0.039 and the fraction of particles more than 0.12 dex high falls from 4.8% to 1.2%.

A warning inside the dropdown records the assumption the reader is buying.  A = u(gam-1)/rho^(gam-1) uses the fixed gam and is the true adiabatic invariant only for a gam-law gas, so the run reports the largest |Gamma_1-gam|/gam it met while integrating a, and a radiation-dominated envelope would need the specific entropy instead.

The sph.input reference page is regenerated from init.f, which is where tswitchtou and the widened nintvar description come from.