### PR TITLE
Derive the drag schedule only for an actual relaxation

### DIFF
--- a/parallel_bleeding_edge/src/relax.f
+++ b/parallel_bleeding_edge/src/relax.f
@@ -65,7 +65,14 @@ c     with a number derived from the wrong object.
          stop 'relax: trelax=0 needs nrelax<2'
       endif
 
-      if(trelax.eq.0.d0 .and. .not.autodone) then
+c     nrelax=0 is a dynamical run, where relax adds no force at all.  The
+c     radius and mass below are measured over every particle in the box, so
+c     for a hyperbolic encounter they describe the separation of the two
+c     stars rather than the size of either, and the schedule derived from
+c     them would be meaningless.  Nothing reads it at nrelax=0, but log0.sph
+c     would report a drag schedule the run does not have.  Derive only for an
+c     actual relaxation.
+      if(trelax.eq.0.d0 .and. nrelax.ne.0 .and. .not.autodone) then
          amtotauto=0.d0
          r2maxauto=0.d0
          do i=1,ntot
@@ -108,7 +115,10 @@ c     corotating binary built from such a snapshot is the case that noticed.
       endif
 
       trelaxeff=trelax
-      if(trelax.eq.0.d0) trelaxeff=trelax0auto
+c     autodone is what guarantees trelax0auto has been assigned.  A dynamical
+c     run left at trelax=0 now skips the block above, so without this test it
+c     would read trelax0auto before anything set it.
+      if(trelax.eq.0.d0 .and. autodone) trelaxeff=trelax0auto
 
       if (nrelax.eq.1) then
          trelaxuse=trelaxeff


### PR DESCRIPTION
relax is called from balAV3 on every step regardless of nrelax; the guard on the call site is commented out.  So a dynamical run enters it too, and if such a run also left trelax at 0 it would fall into the block that derives the schedule.  The stop at the top of that block only catches nrelax>=2, so nrelax=0 went straight through.

What it derived there was meaningless.  amtotauto and r2maxauto are summed over every particle in the box, so for a hyperbolic encounter the radius is essentially the separation of the two stars rather than the size of either, and the dynamical time that comes back belongs to the orbit.  The same reasoning is already written out above the nrelax>=2 stop; nrelax=0 simply was not covered by it.

Nothing consumed the result, because every branch that uses trelaxeff is nrelax 1, 2 or 3, and the other readers of treloff are gated the same way or, at balAV3 line 207 and main.f line 61, satisfied through nrelax=0 and omeg=0 whatever treloff holds.  The visible symptom was therefore confined to log0.sph, which would report a radius, a mass, a t_dyn, a trelax and a treloff for a run that has no drag at all.  That is worth removing: a log that states a schedule is how someone reading the run later decides what it did.

Requiring nrelax/=0 leaves trelax0auto unassigned for a dynamical run left at trelax=0, and it lives in a common block with no block data, so the line below that falls back to it would have read it before anything set it.  It is tested against autodone now, which is the flag that records whether the derivation actually ran.

A relaxation is unaffected: nrelax=1 with trelax=0 derives exactly as before.