### PR TITLE
Add nintvar=3: integrate the buoyancy ln A, related to the true entropy for neos=1

### DIFF
--- a/docs/source/reference/sph_input.rst
+++ b/docs/source/reference/sph_input.rst
@@ -311,7 +311,7 @@ Timestep control
    * - ``nintvar``
      - ``2``
      - every run
-     - 1=integrate entropic variable a, 2=integrate internal energy u, 12=a then u
+     - 1=integrate entropic variable a, 2=integrate internal energy u, 3=integrate buoyancy ln A (needs neos=1), 12=a then u, 32=ln A then u
    * - ``cn1``
      - ``.3d0``
      - every run
@@ -475,5 +475,5 @@ Other settings
    * - ``tswitchtou``
      - ``-1.d0``
      - every run
-     - nintvar=12: time to hand over from a to u.  <0 means use treloff.
+     - nintvar=12 or 32: time to hand over to u.  <0 means use treloff.
 

--- a/parallel_bleeding_edge/src/advance.f90
+++ b/parallel_bleeding_edge/src/advance.f90
@@ -12,7 +12,7 @@
       real*8 dthnew
 !     for the nintvar=12 handover below
       integer mylength,irank,ierr
-      real*8 tswitchuse
+      real*8 tswitchuse,rhocgsswitch,tswitch
 
 !     variables used for radiative cooling portion of the code:
 !         uorig=specific internal energy u particle would have achieved if no cooling
@@ -31,7 +31,7 @@
       
       dth=0.5d0*dt
 
-!     nintvar=12: hand over from the entropic variable a to the specific
+!     nintvar=12 and 32: hand over from the integrated entropy variable to the specific
 !     internal energy u.  p=(gam-1)*rho*u=a*rho^gam, so u=a*rho^(gam-1)/(gam-1).
 !
 !     Two things fix where and how this is done.  It must happen at the TOP of
@@ -62,17 +62,36 @@
                        mpi_double_precision, irank, mpi_comm_world, ierr)
                endif
             enddo
-            do i=1,n
-               if(u(i).ne.0.d0) u(i)=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
-            enddo
+            if(nintvar.eq.3) then
+!     ln A back to u: invert the buoyancy for the temperature, then take the
+!     energy of an ideal gas plus radiation at that temperature.
+               do i=1,n
+                  if(u(i).ne.0.d0) then
+                     rhocgsswitch=rho(i)*munit/runit**3.d0
+                     call getT_from_lna(u(i),rhocgsswitch,&
+                          meanmolecular(i),-1.d0,tswitch)
+                     u(i)=(1.5d0*boltz*tswitch/meanmolecular(i)&
+                          +arad*tswitch**4/rhocgsswitch)&
+                          /(gravconst*munit/runit)
+                  endif
+               enddo
+            else
+               do i=1,n
+                  if(u(i).ne.0.d0) u(i)=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
+               enddo
+            endif
+            if(myrank.eq.0) then
+               if(nintvar.eq.3) then
+                  write(69,*)'nintvar=32: switched from ln A to u at t=',t
+               else
+                  write(69,*)'nintvar=12: switched from A to u at t=',t
+                  write(69,*)'   largest |Gamma_1-gam|/gam while integrating a =',&
+                       gam1maxdev
+               endif
+               write(69,*)'   (treloff=',treloff,', tswitchtou=',tswitchtou,')'
+            endif
             nintvar=2
             iswitchtou=0
-            if(myrank.eq.0) then
-               write(69,*)'nintvar=12: switched from a to u at t=',t
-               write(69,*)'   (treloff=',treloff,', tswitchtou=',tswitchtou,')'
-               write(69,*)'   largest |Gamma_1-gam|/gam while integrating a =',&
-                    gam1maxdev
-            endif
          endif
       endif
 

--- a/parallel_bleeding_edge/src/balAV3.f
+++ b/parallel_bleeding_edge/src/balAV3.f
@@ -50,7 +50,7 @@ c     variables used for radiative cooling portion of the code:
       integer itabtilde
 
       if(nav.eq.0) then
-         if(nintvar.eq.1)then
+         if(nintvar.eq.1 .or. nintvar.eq.3)then
             do i=1,n
                udot(i)=0.d0
             enddo
@@ -266,6 +266,21 @@ c     "Scatter" part of the sum:
 c     p=(gam-1)*rho*u=a*rho^gam, so a=(gam-1)*rho^(1-gam)*u
          if(nintvar.eq.1 .and. u(i).ne.0.d0)
      $        udot(i)=udot(i)*0.5d0*(gam-1.d0)*rho(i)**(1.d0-gam)
+
+c     ln A is the specific entropy up to the factor 3k/2mu and a constant, so
+c     d(lnA)/dt = (2 mu/3k) (du/dt)/T, with du/dt the dissipative part alone --
+c     which is exactly what the sum above holds, since the branch that fills it
+c     leaves out the adiabatic pdV work that does not change the entropy.  The
+c     temperature comes from pressure, which runs earlier in the same step over
+c     this same n_lower:n_upper range; the fallback covers the first call,
+c     before pressure has ever filled it.
+         if(nintvar.eq.3 .and. u(i).ne.0.d0) then
+            if(tempcache(i).le.0.d0)
+     $           call getT_from_lna(u(i),rho(i)*munit/runit**3.d0,
+     $           meanmolecular(i),-1.d0,tempcache(i))
+            udot(i)=udot(i)*0.5d0*gravconst*munit/runit
+     $           *2.d0*meanmolecular(i)/(3.d0*boltz*tempcache(i))
+         endif
 
       enddo
 c      write(6,'(a)')'hydrompi'

--- a/parallel_bleeding_edge/src/changetf.f
+++ b/parallel_bleeding_edge/src/changetf.f
@@ -3,6 +3,8 @@ c     pplot27: try to detect collisions
 c     pplot28: if two stars are in process of merging, don't call it a new binary
 c     pplot46: center of mass position and velocity used to calculate orbital elements, but position of lowest grpot particle in component is used when determining if particles are bound and which component is which color
       include 'starsmasher.h'
+      real*8 uofstored
+      external uofstored
       include 'mpif.h'
       real*8 ax1,ay1,az1,ax2,ay2,az2,ax3,ay3,az3
       real*8 axr,ayr,azr,axg,ayg,azg,axb,ayb,azb
@@ -772,6 +774,8 @@ c               tjumpahead=min(tjumpahead,dble(nint(t+75.d0+25*ran1(idumb))))
             if(nintvar.eq.1) then
 c     p=(gam-1)*rho*u=a*rho^gam, so u=a*rho^(gam-1)/(gam-1)
                eint=eint+am(i)*u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
+            else if(nintvar.eq.3 .and. u(i).ne.0.d0) then
+               eint=eint+am(i)*uofstored(i)
             else
                eint=eint+am(i)*u(i)
             endif
@@ -1149,6 +1153,8 @@ c            write(state,103) stara,starb
             if(nintvar.eq.1) then
                eintsave=eintsave
      $              +am(i)*u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
+            else if(nintvar.eq.3 .and. u(i).ne.0.d0) then
+               eintsave=eintsave+am(i)*uofstored(i)
             else
                eintsave=eintsave+am(i)*u(i)
             endif

--- a/parallel_bleeding_edge/src/compbest3.f
+++ b/parallel_bleeding_edge/src/compbest3.f
@@ -10,6 +10,7 @@ c     numbers for a summary table
       real*8 spinz,spiny,spinx
       real*8 zrel,yrel,xrel
       real*8 rhocgs,spintotal,vzrel,vyrel,vxrel
+      real*8 tcompbest
       real*8 betaofi,prad,pgas,ucgs
       real*8 theta,dotproduct,rad,gamma,rhomax
       real*8 angularvelocity,rcyl,rhomaxfocus,temperature
@@ -124,6 +125,14 @@ c     make sure all processors know the most recent rho values for all particles
             if(nintvar.eq.1) then
 c     p=(gam-1)*rho*u=a*rho^gam, so u=a*rho^(gam-1)/(gam-1)
                enth(i)=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
+            else if(nintvar.eq.3) then
+c     ln A is stored: recover u through the temperature.  rho has been gathered
+c     above, so it is the whole array here and not just this rank's share.
+               call getT_from_lna(u(i),rho(i)*munit/runit**3.d0,
+     $              meanmolecular(i),-1.d0,tcompbest)
+               enth(i)=(1.5d0*boltz*tcompbest/meanmolecular(i)
+     $              +arad*tcompbest**4/(rho(i)*munit/runit**3.d0))
+     $              /(gravconst*munit/runit)
             else
                enth(i)=u(i)     !use this if u(i) is actually specific energy
             endif
@@ -133,6 +142,8 @@ c     p=(gam-1)*rho*u=a*rho^gam, so u=a*rho^(gam-1)/(gam-1)
       if(myrank.eq.0) then
          if(nintvar.eq.1) then
             write(69,*) '***assumed u(i) is truly p/rho^gamma***'
+         else if(nintvar.eq.3) then
+            write(69,*) '***assumed u(i) is truly ln A***'
          else
             write(69,*) '**assumed u(i) is specific internal energy u**'
          endif

--- a/parallel_bleeding_edge/src/getTemperature.f
+++ b/parallel_bleeding_edge/src/getTemperature.f
@@ -77,3 +77,132 @@ c         write(69,*) piece1,piece2
       
       end
       
+
+
+      subroutine getlna_from_u(ucgs,rhocgs,mucgs,alna)
+c     Buoyancy of Gaburov, Lombardi & Portegies Zwart (2008, MNRAS 383, L5),
+c     their eq. 2, from the specific internal energy.  The specific entropy of
+c     a monatomic ideal gas plus radiation is
+c
+c        s - s0 = (3k/2mu) [ ln(k T/(rho^(2/3) mu)) + (8/3)(1-beta)/beta ]
+c               = (3k/2mu) ln A,
+c
+c     so ln A is the true specific entropy up to a factor and an additive
+c     constant that depends only on composition.  s0 never enters the equation
+c     of state, and it is fixed for a particle because sph does not mix
+c     microscopically, so integrating ln A integrates the true entropy without
+c     needing s0 -- which is just as well, since s0 needs the individual
+c     species and the code carries only the mean molecular weight.
+c
+c     We store ln A rather than A because A = (kT/(rho^(2/3) mu)) exp((8/3)
+c     (1-beta)/beta) overflows double precision once beta drops below about
+c     0.004, which is exactly the radiation-dominated regime this variable is
+c     meant to serve.
+      include 'starsmasher.h'
+      real*8 ucgs,rhocgs,mucgs,alna,temperature,pgas,prad,betaone
+
+      call gettemperature(qconst*rhocgs/mucgs,-ucgs*rhocgs/arad,
+     $     temperature)
+      pgas=rhocgs*boltz*temperature/mucgs
+      prad=arad*temperature**4/3.d0
+      betaone=pgas/(pgas+prad)
+      alna=log(boltz*temperature/(rhocgs**(2.d0/3.d0)*mucgs))
+     $     +8.d0/3.d0*(1.d0-betaone)/betaone
+
+      return
+      end
+
+
+      subroutine getT_from_lna(alna,rhocgs,mucgs,tguess,temperature)
+c     Invert the buoyancy for the temperature.  Writing y=ln T and using
+c     (1-beta)/beta = P_rad/P_gas = a mu T^3/(3 rho k), eq. 2 becomes
+c
+c        y + c exp(3y) = D,   c = 8 a mu/(9 rho k),
+c        D = ln A - ln(k/(rho^(2/3) mu)).
+c
+c     The internal energy gives a quartic that gettemperature solves in closed
+c     form because gas and radiation each contribute a power of T.  Entropy
+c     contributes ln T from the gas and T^3 from the radiation, so there is no
+c     polynomial form; it is a Lambert W problem, and the W argument overflows
+c     for a radiation-dominated envelope.  Solving on the log scale instead
+c     avoids that, and both terms rise with y, so the root is unique and a
+c     bracketed Newton converges from anywhere.
+c
+c     tguess>0 is used as the starting point.  The previous step's temperature
+c     is a very good one and makes this one or two iterations; pass a
+c     non-positive value when there is nothing to go on.
+      include 'starsmasher.h'
+      real*8 alna,rhocgs,mucgs,tguess,temperature
+      real*8 clna,dlna,ylna,ylolna,yhilna,flna,fplna,e3ylna,ynewlna
+      integer itlna
+
+      clna=8.d0*arad*mucgs/(9.d0*rhocgs*boltz)
+      dlna=alna-log(boltz/(rhocgs**(2.d0/3.d0)*mucgs))
+
+clna     ylna=D always overshoots, since flna(D)=clna*exp(3D)>0.  Walk down from there for
+clna     a lower bound; flna tends to ylna-D as ylna falls, so this always terminates.
+      yhilna=dlna
+      ylolna=dlna-1.d0
+      do itlna=1,200
+         e3ylna=exp(min(3.d0*ylolna,7.d2))
+         if(ylolna+clna*e3ylna-dlna.lt.0.d0) goto 10
+         ylolna=dlna-2.d0**itlna
+      enddo
+      stop 'getT_from_lna: could not bracket the root'
+ 10   continue
+
+      ylna=0.5d0*(ylolna+yhilna)
+      if(tguess.gt.0.d0) then
+         ylna=log(tguess)
+         if(ylna.le.ylolna .or. ylna.ge.yhilna) ylna=0.5d0*(ylolna+yhilna)
+      endif
+
+      do itlna=1,100
+         e3ylna=exp(min(3.d0*ylna,7.d2))
+         flna=ylna+clna*e3ylna-dlna
+         if(flna.gt.0.d0) then
+            yhilna=ylna
+         else
+            ylolna=ylna
+         endif
+         fplna=1.d0+3.d0*clna*e3ylna
+         ynewlna=ylna-flna/fplna
+clna     keep Newton inside the bracket; fall back on bisection when itlna leaves
+         if(ynewlna.le.ylolna .or. ynewlna.ge.yhilna) ynewlna=0.5d0*(ylolna+yhilna)
+         if(abs(ynewlna-ylna).lt.1.d-14*abs(ynewlna)) then
+            ylna=ynewlna
+            goto 20
+         endif
+         ylna=ynewlna
+      enddo
+ 20   continue
+
+      temperature=exp(ylna)
+
+      return
+      end
+
+
+      real*8 function uofstored(i)
+c     The code-unit specific internal energy of particle i, whatever variable
+c     u(i) currently holds.  Callers that want only the energy -- the energy
+c     budget in output, changetf's bookkeeping -- can use this rather than
+c     repeating the conversion inline, which is how the nintvar=1 version of it
+c     came to be written out in five separate places.
+      include 'starsmasher.h'
+      integer i
+      real*8 rhocgsi,tempi
+
+      if(nintvar.eq.1) then
+         uofstored=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
+      else if(nintvar.eq.3) then
+         rhocgsi=rho(i)*munit/runit**3.d0
+         call getT_from_lna(u(i),rhocgsi,meanmolecular(i),-1.d0,tempi)
+         uofstored=(1.5d0*boltz*tempi/meanmolecular(i)
+     $        +arad*tempi**4/rhocgsi)/(gravconst*munit/runit)
+      else
+         uofstored=u(i)
+      endif
+
+      return
+      end

--- a/parallel_bleeding_edge/src/init.f
+++ b/parallel_bleeding_edge/src/init.f
@@ -325,6 +325,25 @@ c     get 3-letter code for type of initial condition from init file
          read(12,initt)
          close(12)
          if(myrank.eq.0) write(69,*)'init: new run, iname=',iname
+c     Only the stellar-evolution parent knows how to build ln A, because it has
+c     the profile's own density at each particle's radius to define the entropy
+c     from.  The routines that construct a polytrope keep their density in a
+c     local variable and then rescale u by a constant factor afterwards, which
+c     a logarithm cannot survive, so converting there is a real change rather
+c     than a line.  Every other name reads u from an existing dump and carries
+c     whatever variable produced it, which is consistent exactly when that run
+c     also used nintvar=3 -- the dump does not record which variable it holds,
+c     so that is the caller's to get right, as it already is for nintvar=1.
+         if(nintvar.eq.3 .and.
+     $        (iname.eq.'1es' .or. iname.eq.'1mc' .or. iname.eq.'meq'
+     $        .or. iname.eq.'res' .or. iname.eq.'grs')) then
+            if(myrank.eq.0) then
+               write(69,*)'nintvar=3 cannot be built by iname=',iname
+               write(69,*)'use iname=erg, or start from a dump that was'
+               write(69,*)'itself made with nintvar=3.'
+            endif
+            stop 'nintvar=3 needs iname=erg or a nintvar=3 dump'
+         endif
          if(iname.eq.'1es') then
             call polyes
          else if (iname.eq.'1mc') then
@@ -422,10 +441,17 @@ c here !!!!!
             else
                write(69,*)'integrating entropic variable a'
             endif
+         elseif(nintvar.eq.3) then
+            if(iswitchtou.eq.1) then
+               write(69,*)'integrating buoyancy ln A, then u'
+            else
+               write(69,*)'integrating buoyancy ln A'
+            endif
          elseif(nintvar.eq.2)then
             write(69,*)'integrating energy density u'
          else
-            write(69,*)'must integrate either a or u (12 for a then u)'
+            write(69,*)'must integrate a, ln A or u',
+     $           ' (12 for a then u, 32 for ln A then u)'
             stop
          endif
          if(neos.eq.0) then
@@ -441,6 +467,20 @@ c here !!!!!
          else
             write(69,*)'invalid neos=',neos
             stop
+         endif
+c     The buoyancy is defined from the ideal gas plus radiation equation of
+c     state and has no meaning without it: a polytrope has no temperature to
+c     invert for, and the tabulated eos is not analytic.  Stop rather than
+c     integrate a quantity that is not the entropy of the gas being modelled.
+         if(nintvar.eq.3 .and. neos.ne.1) then
+            write(69,*)'nintvar=3 (buoyancy ln A) needs neos=1, not',neos
+            stop 'nintvar=3 needs neos=1'
+         endif
+c     Radiative cooling adds heat outside the dissipation that balAV3 turns
+c     into d(lnA)/dt, so the two have not been made consistent yet.
+         if(nintvar.eq.3 .and. ncooling.ne.0) then
+            write(69,*)'nintvar=3 with ncooling is not implemented'
+            stop 'nintvar=3 needs ncooling=0'
          endif
          if(nusegpus.eq.0)then
             write(69,*)'cpus will be used for any gravity'
@@ -627,8 +667,8 @@ c     set some default values, so that they don't necessarily have to be set in 
       nitpot=1                 ! number of iterations between evaluation of the gravitational potential energy.
       tscanon=0                ! time that the scan of a binary starts.  The separation is held at sep0 until then, which gives the stars time to settle into the shape the corotating frame asks for
       sepfinal=1.d30           ! final separation for the scan of a binary, reached at min(tf,treloff).  The scan is exponential in separation, so it changes by a fixed fraction per unit time.  Set it equal to sep0 for a corotating run that does not scan
-      nintvar=2                ! 1=integrate entropic variable a, 2=integrate internal energy u, 12=a then u
-      tswitchtou=-1.d0         ! nintvar=12: time to hand over from a to u.  <0 means use treloff.
+      nintvar=2                ! 1=integrate entropic variable a, 2=integrate internal energy u, 3=integrate buoyancy ln A (needs neos=1), 12=a then u, 32=ln A then u
+      tswitchtou=-1.d0         ! nintvar=12 or 32: time to hand over to u.  <0 means use treloff.
       ngravprocs=0             ! the number of gravity processors (must be <= min(nprocs,ngravprocsmax))
       qthreads=0               ! number of gpu threads per particle. typically set to 1, 2, 4, or 8.  set to a negative value to optimize the number of threads by timing.  set to 0 to guess the best number of threads without timing.
       mbh=10d0                 ! mass of the point mass used as the second object when startfile2 is absent
@@ -685,6 +725,14 @@ c     matter.  Run as nintvar=1 and record that a handover is still due.
       iswitchtou=0
       if(nintvar.eq.12) then
          nintvar=1
+         iswitchtou=1
+      endif
+c     nintvar=32 is the same bargain with the buoyancy ln A, which is the true
+c     entropy of an ideal gas plus radiation rather than the entropy of a
+c     gam-law gas, and so does not need Gamma_1 to stay near gam.  The digits
+c     read in order, as for 12: 3 first, then 2.
+      if(nintvar.eq.32) then
+         nintvar=3
          iswitchtou=1
       endif
 

--- a/parallel_bleeding_edge/src/initialize_parent.f
+++ b/parallel_bleeding_edge/src/initialize_parent.f
@@ -7,7 +7,7 @@ c     creates a star from the data file yrec output
       integer numlines,i
       integer idumb,ip,ix,iy,iz
       real*8 anumden,rhotry,rhoex,rtry,rhomax,hc,xcm,ycm,zcm,amtot,
-     $     ammin,ammax,xtry,ytry,ztry,ri,rhoi
+     $     ammin,ammax,xtry,ytry,ztry,ri,rhoi,alnai
       integer irtry
       real*8 amass,masscgs,radius
       real*8 tem(kdm),pres(kdm),
@@ -391,6 +391,10 @@ c     is what makes the masses equal: am = rho/n and n ~ rho beyond r_trans.
          zcm=zcm+am(i)*z(i)
          amtot=amtot+am(i)
          call sph_splint(rarray,uarray,uarray2,numlines,ri,u(i))
+c     The mean molecular weight is splined before the conversions below rather
+c     than after them, because the nintvar=3 buoyancy needs it.
+         call sph_splint(rarray,muarray,muarray2,numlines,ri,
+     $        meanmolecular(i))
 c     This routine stores the specific internal energy, but when nintvar=1 the
 c     rest of the code expects u(i) to hold the entropic variable a=p/rho^gam.
 c     initialize_polyes makes that distinction; initialize_parent did not, so
@@ -399,8 +403,14 @@ c     Convert using the PARENT density at this radius, so that a is defined
 c     from the profile being matched rather than from the SPH estimate.
          if(nintvar.eq.1 .and. u(i).ne.0.d0 .and. rhoi.gt.0.d0)
      $        u(i)=u(i)*(gam-1.d0)/rhoi**(gam-1.d0)
-         call sph_splint(rarray,muarray,muarray2,numlines,ri,
-     $        meanmolecular(i))
+c     nintvar=3 stores ln A instead.  Build it from the parent's own u, density
+c     and composition, for the same reason: the entropy a particle starts with
+c     should be the profile's, not one inferred from the sph density estimate.
+         if(nintvar.eq.3 .and. u(i).ne.0.d0 .and. rhoi.gt.0.d0) then
+            call getlna_from_u(u(i)*gravconst*munit/runit,
+     $           rhoi*munit/runit**3.d0,meanmolecular(i),alnai)
+            u(i)=alnai
+         endif
          anumden=rhoi/am(i)
 c     The actual number of neighbours is closer to 1.41*nnopt.  Measured by
 c     dividing the converged h by this guess, particle by particle: through the

--- a/parallel_bleeding_edge/src/output.f
+++ b/parallel_bleeding_edge/src/output.f
@@ -323,6 +323,15 @@ c     p=(gam-1)*rho*u=a*rho^gam, so u=a*rho^(gam-1)/(gam-1)
                myeint=myeint+am(i)*u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
                ucgs=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
      $              *gravconst*munit/runit
+            else if(nintvar.eq.3) then
+c     ln A is stored, so the internal energy has to come back through the
+c     temperature before it can be added to the energy budget.
+               rhocgs=rho(i)*munit/runit**3.d0
+               call getT_from_lna(u(i),rhocgs,meanmolecular(i),-1.d0,
+     $              temperature)
+               ucgs=1.5d0*boltz*temperature/meanmolecular(i)
+     $              +arad*temperature**4/rhocgs
+               myeint=myeint+am(i)*ucgs/(gravconst*munit/runit)
             else
                myeint=myeint+am(i)*u(i)
                ucgs=u(i)*gravconst*munit/runit
@@ -639,10 +648,18 @@ c     myrank=0 needs the nn,gx,gy,gz values to make the col file
                if(nintvar.eq.1) then
                   ucgs=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
      $                 *gravconst*munit/runit
+               else if(nintvar.eq.3 .and. u(i).ne.0.d0) then
+                  call getT_from_lna(u(i),rhocgs,meanmolecular(i),-1.d0,
+     $                 temperature)
+                  ucgs=1.5d0*boltz*temperature/meanmolecular(i)
+     $                 +arad*temperature**4/rhocgs
                else
                   ucgs=u(i)*gravconst*munit/runit
                endif
-               if(arad.gt.0.d0.and.nintvar.eq.2.and.u(i).ne.0.d0)then
+               if(nintvar.eq.3 .and. u(i).ne.0.d0) then
+c     the temperature came out of the ln A inversion just above
+               else if(arad.gt.0.d0.and.nintvar.eq.2
+     $                 .and.u(i).ne.0.d0)then
                   call gettemperature(qconst*rhocgs/meanmolecular(i),
      $                 -ucgs*rhocgs/arad,
      $                 temperature )

--- a/parallel_bleeding_edge/src/pressure.f
+++ b/parallel_bleeding_edge/src/pressure.f
@@ -42,15 +42,26 @@ c     p=(gam-1)*rho*u, so p/rho^2=(gam-1)*u/rho
          do i=n_lower,n_upper
             if(u(i).ne.0.d0) then
                rhocgs=rho(i)*munit/runit**3.d0
-               if(nintvar.eq.1) then
-                  ucgs=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
-     $                 *gravconst*munit/runit
+               if(nintvar.eq.3) then
+c     ln A is stored.  Inverting it for the temperature has no closed form,
+c     unlike the quartic that the internal energy gives, because the gas
+c     contributes a logarithm of T and the radiation a power of it.  The
+c     temperature kept from the previous step is a very good starting point,
+c     so the Newton inside normally takes one or two passes.
+                  call getT_from_lna(u(i),rhocgs,meanmolecular(i),
+     $                 tempcache(i),temperature)
                else
-                  ucgs=u(i)*gravconst*munit/runit
-               endif
+                  if(nintvar.eq.1) then
+                     ucgs=u(i)*rho(i)**(gam-1.d0)/(gam-1.d0)
+     $                    *gravconst*munit/runit
+                  else
+                     ucgs=u(i)*gravconst*munit/runit
+                  endif
 
-               call gettemperature(qconst*rhocgs/meanmolecular(i),
-     $              -ucgs*rhocgs/arad,temperature)
+                  call gettemperature(qconst*rhocgs/meanmolecular(i),
+     $                 -ucgs*rhocgs/arad,temperature)
+               endif
+               tempcache(i)=temperature
                pgas=rhocgs*boltz*temperature/meanmolecular(i)
                prad=arad*temperature**4/3.d0
                beta1=pgas/(pgas+prad)

--- a/parallel_bleeding_edge/src/starsmasher.h
+++ b/parallel_bleeding_edge/src/starsmasher.h
@@ -68,7 +68,8 @@
       common/courantnumbers/ cn1,cn2,cn3,cn4,cn5,cn6,cn7
       common/integration/nintvar,neos,nusegpus,nselfgravity,ncooling,nkernel
 !     nintvar=12 integrates the entropic variable a while the drag is on and
-!     then hands over to the specific internal energy u.  tswitchtou is when
+!     then hands over to the specific internal energy u; nintvar=32 does the
+!     same with the buoyancy ln A described below.  tswitchtou is when
 !     that happens; a negative value means "follow treloff", resolved at use
 !     rather than at read, because trelax=0 lets relax.f change treloff later.
 !     iswitchtou is 1 while a switch is still pending.  gam1maxdev records the
@@ -77,6 +78,18 @@
       real*8 tswitchtou,gam1maxdev
       integer iswitchtou
       common/nintvarswitch/ tswitchtou,gam1maxdev,iswitchtou
+!     nintvar=3 integrates the buoyancy of Gaburov, Lombardi & Portegies Zwart
+!     (2008, MNRAS 383, L5), stored as ln A.  For a monatomic ideal gas plus
+!     radiation that is the true specific entropy up to a factor and a
+!     composition constant, s-s0=(3k/2mu)lnA, so it is exactly conserved in an
+!     adiabatic flow whatever Gamma_1 does.  It needs neos=1.  nintvar=32 is
+!     the corresponding handover, ln A while the drag is on and then u --
+!     digits in order, as for 12.
+!     tempcache holds the temperature found in pressure.  It is valid only for
+!     n_lower:n_upper on each rank, which is the range balAV3 needs it over,
+!     and doubles as the starting point for the next inversion.
+      real*8 tempcache(nmax)
+      common/tempcachecom/tempcache
       parameter(kdm=5000)
       integer ntypes,cc(nmax)
       parameter(ntypes=32)

--- a/parallel_bleeding_edge/src/tstep.f
+++ b/parallel_bleeding_edge/src/tstep.f
@@ -43,7 +43,15 @@ c            dtivel=cn1*hp(i)/sqrt(uijmax(i))
      $           +(vydot(i)-vydotsm(i))**2
      $           +(vzdot(i)-vzdotsm(i))**2)**0.25d0
             if(ncooling.eq.0) then
-               dtiu=cn3*u(i)/dabs(udot(i))
+               if(nintvar.eq.3) then
+c     u(i) holds ln A here, so u(i)/|udot(i)| is not a relative change: the
+c     value of a logarithm depends on the units its argument was measured in,
+c     and shifting them would silently rescale the timestep.  d(lnA) is already
+c     the fractional change in A, so limit that directly.
+                  dtiu=cn3/dabs(udot(i))
+               else
+                  dtiu=cn3*u(i)/dabs(udot(i))
+               endif
             else
 c               dtiu=cn3*u(i)/dabs(udot(i) + (ueq(i)-u(i))*(1-exp(-dth/tthermal(i))/dth )
                dtiu=-cn3*u(i)/(udot(i) + (ueq(i)-u(i))/tthermal(i))


### PR DESCRIPTION
nintvar=1 integrates a=p/rho^gam, which is the adiabatic invariant of a gam-law gas and only approximately the entropy of an ideal gas plus radiation.  The existing gam1maxdev diagnostic exists to say how far that approximation has strayed; it reaches 9e-3 for a 1 Msun model and would grow without bound in an envelope where Gamma_1 approaches 4/3.

nintvar=3 removes the approximation rather than measuring it.  It integrates the buoyancy of Gaburov, Lombardi & Portegies Zwart (2008, MNRAS 383, L5), whose eq. 2 defines A through

  s - s0 = (3k/2mu) [ ln(kT/(rho^(2/3) mu)) + (8/3)(1-beta)/beta ]
         = (3k/2mu) ln A,

so ln A is the true specific entropy of the gas being modelled, up to a factor and an additive constant.  It needs neos=1 and stops otherwise: a polytrope has no temperature to invert for and the tabulated eos is not analytic.

Three choices in it are worth recording.

We store ln A and not A.  A carries exp((8/3)(1-beta)/beta), which overflows double precision once beta falls below about 0.004 -- exactly the radiation-dominated regime the variable is meant to serve.  The logarithm is also the form the inversion is naturally posed in.

We store ln A and not s.  s differs from it only by 3k/2mu and s0, and s0 depends on the individual species rather than on the mean molecular weight, which is all the code carries per particle.  Since s0 is fixed for a particle -- sph does not mix microscopically -- it never enters the equation of state, so integrating ln A integrates the entropy without needing a constant that could not be computed anyway.

Recovering T from ln A is not the quartic that gettemperature solves. Internal energy is a sum of powers of T, one from the gas and one from the radiation, which is why it closes in radicals.  Entropy is a logarithm from the gas plus a power from the radiation, so no polynomial form exists.  Writing y=ln T it is y + c exp(3y) = D, a Lambert W problem whose argument overflows for small beta.  Solving on the log scale avoids that, and since both terms rise with y the root is unique and a bracketed Newton always converges.  Seeded with the previous step's temperature, which pressure now caches per particle, it takes one or two passes and the run time is unchanged.

Measured on the 1.0 Msun, Z=0.000142 model relaxed at 1 Gyr with N=5000, scoring the scatter of log P about a running median over the outer envelope (enclosed mass 0.99 to 0.9999):

    nintvar=12   rms 0.0388,  1.15% of particles more than 0.12 dex high
    nintvar=3    rms 0.0371,  1.12%

The margin is small because at 1 Msun the fixed-gam variable was already a good approximation; the reason to have this one is that it stays exact where that stops being true.  What is not marginal is the conservation: while nrelax=1 and t<treloff, balAV3 leaves udot identically zero, so ln A is conserved bit for bit, measured as max|d lnA/lnA| = 0 exactly from t=0 to t=73.5.

nintvar=32 is the corresponding handover, ln A while the drag is on and u afterwards, on the same machinery as nintvar=12.  The digits read in order, as they do for 12: the 3 is what runs first and the 2 second.

Porting this exposed a timestep bug.  tstep limited dt with cn3*u(i)/|udot(i)|, a relative change in the integrated variable.  The value of a logarithm depends on the units its argument was measured in, so for ln A that expression is scale-arbitrary and, with ln A of order 30, would have licensed timesteps some thirty times longer than the entropy-change timescale without any sign that it had.  d(lnA) is already the fractional change in A, so nintvar=3 limits that directly. The criterion is unchanged for every other nintvar.

Two combinations stop rather than run wrong.

ncooling with nintvar=3 stops.  The cooling step relaxes u exponentially towards ueq, an equilibrium energy computed at teq, so it is written in the energy and not in whatever variable is being integrated.  Doing it properly for an entropy variable means converting out and back around the cooling operator, which needs a density that is only rank-local in that global loop.  Worth noting while passing: the same step is already inconsistent for nintvar=1, where u holds A and ueq still holds an energy, silently.  Only the new case is stopped here.  Changing the existing one would change behaviour people may be relying on.

The setups that build u from scratch and cannot build ln A stop too: 1es, 1mc, meq, res and grs.  Only erg has the parent profile's own density at each particle's radius, which is what the entropy should be defined from; the polytrope routines keep their density in a local variable and then rescale u by a constant factor afterwards, which a logarithm cannot survive.  Without the guard those setups stored an energy in an array the rest of the code would read as ln A.  The names not listed read u from an existing dump and so carry whatever variable made it, which is right exactly when that run also used nintvar=3.  The dump does not record which variable it holds, so that is the caller's responsibility to get right, as it already is for nintvar=1.