### PR TITLE
units: let sph.input set gravconst, alongside munit and runit

### DIFF
--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -227,7 +227,7 @@ GROUPS = [
  ('Timestep control', ['nintvar','cn1','cn2','cn3','cn4','cn5','cn6','cn7']),
  ('Parallelism and GPUs',
                      ['ngravprocs','qthreads','ppn','computeexclusivemode','gflag']),
- ('Units',           ['runit','munit']),
+ ('Units',           ['runit','munit','gravconst']),
  ('Input files',     ['startfile1','startfile2','startfile3','binaryfile','triplefile',
                       'bpbhfile','imagefile','advectedfile',
                       'eosfile','opacityfile','profilefile',

--- a/docs/source/reference/sph_input.rst
+++ b/docs/source/reference/sph_input.rst
@@ -16,7 +16,7 @@ begins with ``&input`` and ends with ``&end``::
 
    The variables, defaults and descriptions on this page are read directly
    from the namelist declaration and the default-initialisation block in
-   ``parallel_bleeding_edge/src/init.f``.  There are **76** settings.
+   ``parallel_bleeding_edge/src/init.f``.  There are **77** settings.
 
 
 .. _sph-input-time-and-output:
@@ -396,6 +396,10 @@ Units
      - ``1.9884098706980504d33``
      - every run
      - number of g in unit of mass.  use 1.9884098706980504E+033 if want MESA solar mass.
+   * - ``gravconst``
+     - ``6.67430d-08``
+     - every run
+     - newton's gravitational constant in cgs.  2018 CODATA value; older StarSmasher runs used 6.67390d-08
 
 .. _sph-input-input-files:
 

--- a/parallel_bleeding_edge/src/init.f
+++ b/parallel_bleeding_edge/src/init.f
@@ -58,6 +58,8 @@ c     compute look-up tables:
          write(69,*) 'These are the code units being used:'
          write(69,*) '   mass unit=',munit,'g'
          write(69,*) '   radius unit=',runit,'cm'
+         write(69,*) '   gravitational constant=',gravconst,
+     $        'cm^3/(g s^2)'
          write(69,*) '   pressure unit=',punit,'dyne/cm^2'
       endif  
 
@@ -609,6 +611,7 @@ c      end
      $     nrelax,trelax,sep0,impactparameter,e0,semimajoraxis,vinf2,
      $     equalmass,treloff,tresplintmuoff,nitpot,tscanon,sepfinal,
      $     nintvar,tswitchtou,ngravprocs,qthreads,gflag,mbh,runit,munit,
+     $     gravconst,
      $     cn1,cn2,cn3,cn4,cn5,cn6,cn7,computeexclusivemode,ppn,
      $     omega_spin,neos,nselfgravity,gam,reat,starmass,starradius,
      $     ncooling,teq,tjumpahead,startfile1,startfile2,eosfile,
@@ -674,6 +677,7 @@ c     set some default values, so that they don't necessarily have to be set in 
       mbh=10d0                 ! mass of the point mass used as the second object when startfile2 is absent
       runit=6.957d10          ! number of cm in the unit of length.  use 6.957d10 if want MESA solar radius.
       munit=1.9884098706980504d33          ! number of g in unit of mass.  use 1.9884098706980504E+033 if want MESA solar mass.
+      gravconst=6.67430d-08    ! newton's gravitational constant in cgs.  2018 CODATA value; older StarSmasher runs used 6.67390d-08
 !     the courant numbers cn1, cn2, cn3, and cn4 are for sph particles:
 !     dt_sph=1/(1/dt1 + 1/dt2 + 1/dt3 + 1/dt4)
       cn1=.3d0                 ! dt1=cn1*h/v_signal

--- a/parallel_bleeding_edge/src/starsmasher.h
+++ b/parallel_bleeding_edge/src/starsmasher.h
@@ -39,8 +39,7 @@
       parameter(sigma=pi**2*boltz*(boltz*2d0*pi/planck)**3/60d0/crad2)
       parameter(arad=4.0d0*sigma/crad,qconst=1.5d0*boltz/arad)
       real*8 munit,runit,punit,gravconst,redge
-      parameter(gravconst = 6.67430d-08)
-      common/units/munit,runit,punit
+      common/units/munit,runit,punit,gravconst
       common/artvis/ alpha,beta,nav
       integer computeexclusivemode,ppn
       common/grav/ ngr,computeexclusivemode


### PR DESCRIPTION
Newton's constant was a compile-time parameter in starsmasher.h, so changing it meant editing a header and rebuilding.  It is now a namelist variable in common/units/, read from sph.input beside the other two constants that define the unit system.

The default is the same 6.67430d-08 the parameter carried, so a run that does not mention gravconst behaves exactly as before.  Setting it matters mostly for reproducing older work: runs made with the previous unit system used 6.67390d-08, and matching a published result means matching the constant it was computed with, not just munit and runit.

gravconst appears only in executable expressions, never in a parameter or data statement, so nothing needed a compile-time value.  The gravity libraries do not reference it at all.  Every rank runs get_input, so the common block is filled consistently without a broadcast.

init now prints the value with the rest of the code units, since a constant that can vary between runs should be recorded in the log rather than inferred from the source.

One caveat, shared with munit and runit: gravconst is not written to restartrad.sph, so it has to stay in sph.input for a restart to continue with the same constant.

The sph.input reference page is regenerated to match.